### PR TITLE
Improve CSV support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('requirements/common.txt', 'r') as r:
 
 setup(
     name=package_name,
-    version='0.1.0',
+    version='0.2.0',
     author='Rune Labs',
     maintainer_email='support@runelabs.io',
     description='Query data from Rune Labs APIs',

--- a/tests/stream/test_v1.py
+++ b/tests/stream/test_v1.py
@@ -119,7 +119,6 @@ class TestStreamV1Client(TestCase):
         Test the signature of CSV requests.
 
         """
-        # CSV-supported
         for test_num, case in enumerate((
             (self.client.Accel, '/v1/accel.csv'),
             (self.client.LFP, '/v1/lfp.csv'),
@@ -142,10 +141,6 @@ class TestStreamV1Client(TestCase):
                     }
                 ),
             ])
-
-        # CSV not supported
-        with self.assertRaises(NotImplementedError):
-            self.client.Event().get_csv_response()
 
     def test_iter_json_data(self):
         """
@@ -258,11 +253,10 @@ class TestStreamV1Client(TestCase):
 
             # Check that all parameters were kept the same across calls,
             # except for "page" (which must be incremented)
-            # Page and page size have defaults, if they aren't set
             self.assertEqual(calls, [
-                ((), {'test_num': test_num, 'page': 0, 'page_size': 100000}),
-                ((), {'test_num': test_num, 'page': 1, 'page_size': 100000}),
-                ((), {'test_num': test_num, 'page': 2, 'page_size': 100000}),
+                ((), {'test_num': test_num, 'page': 0}),
+                ((), {'test_num': test_num, 'page': 1}),
+                ((), {'test_num': test_num, 'page': 2}),
             ])
 
             #


### PR DESCRIPTION
* Adding a `iter_csv_availability` convenience method: it uses the availability expression with a resource's CSV endpoint
* Removing the default CSV page limit, in favor of the default set by the API itself. Users can still specify the page limit through kwargs.
* Adding `StreamV1CSVBase`, to clarify support for CSV formatted data. This will improve the autogenerated docs, particularly for the `Event` accessor. Does not change the public interface.

Bumping version to 0.2.0