### PR TITLE
add support for new pagination methodology

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('requirements/common.txt', 'r') as r:
 
 setup(
     name=package_name,
-    version='0.2.0',
+    version='0.3.0',
     author='Rune Labs',
     maintainer_email='support@runelabs.io',
     description='Query data from Rune Labs APIs',


### PR DESCRIPTION
This pull request seeks to change the pagination methodology used by the SDK when the X-Rune-Next-Page-Token header field is present. When the header field is present, the next_page_token query string parameter should be used to request the next page. If the header field is not present, the SDK should utilize the page query string parameter.

Note: when the next_page_token query string parameter is specified in the request, the page query string parameter must not be present. Therefore, the page query string parameter is removed from the params when the next_page_token query string parameter is added.