### PR TITLE
[DATA-490] Remove some redundant helper functions; documentation; small bugfix

### DIFF
--- a/runeq/config.py
+++ b/runeq/config.py
@@ -1,5 +1,5 @@
 """
-Configuration for API access
+Configuration for accessing Rune APIs.
 
 """
 import os
@@ -33,7 +33,7 @@ Default path for the config file (yaml formatted)
 
 class Config:
     """
-    Config holds configuration (e.g. auth credentials, URLs, etc)
+    Holds configuration (e.g. auth credentials, URLs, etc)
 
     """
 
@@ -228,7 +228,7 @@ class Config:
     @property
     def auth_headers(self):
         """
-        Authentication headers for HTTP requests.
+        Authentication headers for HTTP requests to Rune APIs.
 
         """
         if self.auth_method == AUTH_METHOD_ACCESS_TOKEN:

--- a/runeq/resources/__init__.py
+++ b/runeq/resources/__init__.py
@@ -6,10 +6,11 @@ By default, globally-initialized clients are used for all API requests (see
 also accept optional client(s), which can be used in lieu of the global
 initialization.
 
-Metadata is fetched from Rune's GraphQL API (https://graph.runelabs.io/graphql),
-using a :class:`~runeq.resources.client.GraphClient`. Timeseries data is fetched
-from the `V2 Stream API <https://docs.runelabs.io/stream/v2/index.html>`_, using
-a :class:`~runeq.resources.client.StreamClient`.
+Metadata is fetched from Rune's GraphQL API
+(https://graph.runelabs.io/graphql), using a
+:class:`~runeq.resources.client.GraphClient`. Timeseries data is fetched
+from the `V2 Stream API <https://docs.runelabs.io/stream/v2/index.html>`_,
+using a :class:`~runeq.resources.client.StreamClient`.
 
 """
 from runeq.resources import client

--- a/runeq/resources/__init__.py
+++ b/runeq/resources/__init__.py
@@ -13,4 +13,3 @@ from the `V2 Stream API <https://docs.runelabs.io/stream/v2/index.html>`_,
 using a :class:`~runeq.resources.client.StreamClient`.
 
 """
-from runeq.resources import client

--- a/runeq/resources/__init__.py
+++ b/runeq/resources/__init__.py
@@ -1,5 +1,15 @@
 """
-The Rune Labs V2 Standard Development Kit (SDK) resources for querying data
-from Rune APIs.
+Fetch data from Rune APIs.
+
+By default, globally-initialized clients are used for all API requests (see
+:class:`~runeq.resources.client.initialize`). Functions that make API requests
+also accept optional client(s), which can be used in lieu of the global
+initialization.
+
+Metadata is fetched from Rune's GraphQL API (https://graph.runelabs.io/graphql),
+using a :class:`~runeq.resources.client.GraphClient`. Timeseries data is fetched
+from the `V2 Stream API <https://docs.runelabs.io/stream/v2/index.html>`_, using
+a :class:`~runeq.resources.client.StreamClient`.
 
 """
+from runeq.resources import client

--- a/runeq/resources/client.py
+++ b/runeq/resources/client.py
@@ -134,6 +134,11 @@ class StreamClient:
                 responses are parsed as JSON. Otherwise, the response is
                 returned as text.
 
+        Returns:
+            Iterator over the API responses. If the format parameter is "json",
+            each value is a dictionary. Otherwise, each value is a
+            CSV-formatted string (the default for the V2 API).
+
         Raises:
             errors.APIError
 

--- a/runeq/resources/client.py
+++ b/runeq/resources/client.py
@@ -147,7 +147,9 @@ class StreamClient:
             raise ValueError("path must begin with /v2")
 
         url = urllib.parse.urljoin(self.config.stream_url, path)
-        return_json = params.get("format", "json") == "json"
+
+        # V2 endpoints return CSV-formatted responses by default
+        return_json = params.get("format") == "json"
 
         while True:
             r = requests.get(

--- a/runeq/resources/patient.py
+++ b/runeq/resources/patient.py
@@ -484,7 +484,7 @@ def get_all_devices(
 
     """
     if not patients:
-        return get_all_patients(client=client).devices()
+        return get_all_patients(client=client).devices
 
     if type(patients) is list:
         all_devices = DeviceSet()

--- a/runeq/resources/patient.py
+++ b/runeq/resources/patient.py
@@ -484,7 +484,7 @@ def get_all_devices(
 
     """
     if not patients:
-        return get_all_patients(client=client).devices
+        return get_all_patients(client=client).devices()
 
     if type(patients) is list:
         all_devices = DeviceSet()

--- a/runeq/resources/stream.py
+++ b/runeq/resources/stream.py
@@ -53,8 +53,8 @@ def get_stream_data(
         translate_enums: If True, enum values are returned as their string
             representation. Otherwise, enums are returned as integer values.
         client: If specified, this client is used to fetch data from the
-            API. Otherwise, the global :class:`~runeq.resources.client.StreamClient`
-            is used.
+            API. Otherwise, the global
+            :class:`~runeq.resources.client.StreamClient` is used.
 
     Returns:
         An iterator over paginated API responses. If format is "json", each
@@ -126,8 +126,8 @@ def get_stream_availability(
             what type of batch calculation will determine availability for
             multiple streams. Availability values will equal 1 when
             data is available for "all" or "any" of the requested streams in
-            the given interval.
-            This argument is required when multiple **stream_ids** are specified.
+            the given interval. This argument is required when multiple
+            **stream_ids** are specified.
         format: Either "csv" (default) or "json". Determines the content type
             of the API response.
         limit: Maximum number of timestamps to return, across *all pages*
@@ -143,8 +143,8 @@ def get_stream_availability(
             For example, PST (UTC-0800) is represented as -28800.
             If omitted, the timezone is UTC.
         client: If specified, this client is used to fetch data from the
-            API. Otherwise, the global :class:`~runeq.resources.client.StreamClient`
-            is used.
+            API. Otherwise, the global
+            :class:`~runeq.resources.client.StreamClient` is used.
 
     Returns:
         An iterator over paginated API responses. If format is "json", each

--- a/runeq/resources/stream.py
+++ b/runeq/resources/stream.py
@@ -4,7 +4,7 @@ Query data directly from the V2 Stream API.
 """
 from datetime import datetime
 import time
-from typing import Iterator, List, Optional, Union
+from typing import Iterable, Iterator, Optional, Union
 
 from .client import StreamClient, global_stream_client
 
@@ -97,7 +97,7 @@ def get_stream_data(
 
 
 def get_stream_availability(
-    stream_ids: Union[str, List[str]],
+    stream_ids: Union[str, Iterable[str]],
     start_time: Union[float, datetime.date],
     end_time: Union[float, datetime.date],
     resolution: int,
@@ -175,9 +175,13 @@ def get_stream_availability(
 
     client = client or global_stream_client()
 
+    # If stream_ids is not a string, convert it to a list so that we can
+    if type(stream_ids) is not str:
+        stream_ids = list(stream_ids)
+
     if type(stream_ids) is str:
         path = f"/v2/streams/{stream_ids}/availability"
-    elif type(stream_ids) is list and len(stream_ids) == 1:
+    elif len(stream_ids) == 1:
         path = f"/v2/streams/{stream_ids[0]}/availability"
     else:
         # If querying for batch availability, need batch_operation

--- a/runeq/resources/stream.py
+++ b/runeq/resources/stream.py
@@ -1,5 +1,5 @@
 """
-V2 SDK functionality to support Stream operations.
+Query data directly from the V2 Stream API.
 
 """
 from datetime import datetime
@@ -22,9 +22,9 @@ def get_stream_data(
     timezone: Optional[int] = None,
     translate_enums: Optional[bool] = True,
     client: Optional[StreamClient] = None
-) -> Iterator[str]:
+) -> Iterator[Union[str, dict]]:
     """
-    Gets an iterator over one page of stream data.
+    Fetch raw data for a stream.
 
     Args:
         stream_id: ID of the stream
@@ -35,30 +35,38 @@ def get_stream_data(
         end_time: End time for the query, provided as a unix timestamp
             (in seconds) or a datetime.date.
         end_time_ns: End time for the query, provided as a unix timestamp
-            (in nanoseconds).format: Optional enum "json" or "csv", which
-            determines the content type of the response
+            (in nanoseconds).
+        format: Either "csv" (default) or "json". Determines the content type
+            of the API response.
         limit: Maximum number of timestamps to return, across *all pages*
             of the response. A limit of 0 (default) will fetch all
             available data.
         page_token: Token to fetch the subsequent page of results.
-            The value is obtained from the 'X-Rune-Next-Page-Token'
+            The value is obtained from the "X-Rune-Next-Page-Token"
             response header field.
-        timestamp: Optional enum "unix", "unixns", or "iso", which determines
+        timestamp: One of "unix", "unixns", or "iso", which determines
             how timestamps are formatted in the response
-        timezone: Optional timezone offset, in seconds, used to calculate
+        timezone: Timezone offset, in seconds, used to calculate
             string-based timestamp formats such as datetime and iso.
             For example, PST (UTC-0800) is represented as -28800.
             If omitted, the timezone is UTC.
         translate_enums: If True, enum values are returned as their string
             representation. Otherwise, enums are returned as integer values.
         client: If specified, this client is used to fetch data from the
-            API. Otherwise, the global StreamClient is used.
+            API. Otherwise, the global :class:`~runeq.resources.client.StreamClient`
+            is used.
+
+    Returns:
+        An iterator over paginated API responses. If format is "json", each
+        response is a dict. If format is "csv", each response is a
+        CSV-formatted string.
 
     """
     if start_time and start_time_ns:
         raise ValueError(
             "only start_time or start_time_ns can be defined, not both."
         )
+
     if end_time and end_time_ns:
         raise ValueError(
             "only end_time or end_time_ns can be defined, not both."
@@ -70,151 +78,26 @@ def get_stream_data(
     if type(end_time) is datetime.date:
         end_time = time.mktime(end_time.timetuple())
 
-    params = {
-        'start_time': start_time,
-        'start_time_ns': start_time_ns,
-        'end_time': end_time,
-        'end_time_ns': end_time_ns,
-        'format': format,
-        'limit': limit,
-        'page_token': page_token,
-        'timestamp': timestamp,
-        'timezone': timezone,
-        'translate_enums': translate_enums,
-    }
-
     client = client or global_stream_client()
-    url = f"{client.config.stream_url}/v2/streams/{stream_id}"
+    path = f"/v2/streams/{stream_id}"
 
-    yield from client.get_data(url, **params)
-
-
-def get_stream_csv(
-    stream_id: str,
-    start_time: Optional[Union[float, datetime.date]] = None,
-    start_time_ns: Optional[int] = None,
-    end_time: Optional[Union[float, datetime.date]] = None,
-    end_time_ns: Optional[int] = None,
-    limit: Optional[int] = None,
-    page_token: Optional[str] = None,
-    timestamp: Optional[str] = "iso",
-    timezone: Optional[int] = None,
-    translate_enums: Optional[bool] = True,
-    client: Optional[StreamClient] = None
-) -> Iterator[str]:
-    """
-    Iterate over CSV-formatted data for this stream.
-
-    Args:
-        stream_id: ID of the stream
-        start_time: Start time for the query, provided as a unix timestamp
-                (in seconds) or a datetime.date.
-        start_time_ns: Start time for the query, provided as a unix timestamp
-            (in nanoseconds).
-        end_time: End time for the query, provided as a unix timestamp
-            (in seconds) or a datetime.date.
-        end_time_ns: End time for the query, provided as a unix timestamp
-            (in nanoseconds).format: Optional enum "json" or "csv", which
-            determines the content type of the response
-        limit: Maximum number of timestamps to return, across *all pages*
-            of the response. A limit of 0 (default) will fetch all
-            available data.
-        page_token: Token to fetch the subsequent page of results.
-            The value is obtained from the 'X-Rune-Next-Page-Token'
-            response header field.
-        timestamp: Optional enum "unix", "unixns", or "iso", which determines
-            how timestamps are formatted in the response
-        timezone: Optional timezone offset, in seconds, used to calculate
-            string-based timestamp formats such as datetime and iso.
-            For example, PST (UTC-0800) is represented as -28800.
-            If omitted, the timezone is UTC.
-        translate_enums: If True, enum values are returned as their string
-            representation. Otherwise, enums are returned as integer values.
-        client: If specified, this client is used to fetch data from the
-            API. Otherwise, the global StreamClient is used.
-
-    """
-    params = {
-        'stream_id': stream_id,
-        'start_time': start_time,
-        'start_time_ns': start_time_ns,
-        'end_time': end_time,
-        'end_time_ns': end_time_ns,
-        'format': 'csv',
-        'limit': limit,
-        'page_token': page_token,
-        'timestamp': timestamp,
-        'timezone': timezone,
-        'translate_enums': translate_enums,
-        'client': client,
-    }
-    return get_stream_data(**params)
-
-
-def get_stream_json(
-    stream_id: str,
-    start_time: Optional[Union[float, datetime.date]] = None,
-    start_time_ns: Optional[int] = None,
-    end_time: Optional[Union[float, datetime.date]] = None,
-    end_time_ns: Optional[int] = None,
-    limit: Optional[int] = None,
-    page_token: Optional[str] = None,
-    timestamp: Optional[str] = "iso",
-    timezone: Optional[int] = None,
-    translate_enums: Optional[bool] = True,
-    client: Optional[StreamClient] = None
-) -> Iterator[str]:
-    """
-    Iterate over JSON-formatted API responses for this stream
-
-    Args:
-        stream_id: ID of the stream
-        start_time: Start time for the query, provided as a unix timestamp
-                (in seconds) or a datetime.date.
-        start_time_ns: Start time for the query, provided as a unix timestamp
-            (in nanoseconds).
-        end_time: End time for the query, provided as a unix timestamp
-            (in seconds) or a datetime.date.
-        end_time_ns: End time for the query, provided as a unix timestamp
-            (in nanoseconds).format: Optional enum "json" or "csv", which
-            determines the content type of the response
-        limit: Maximum number of timestamps to return, across *all pages*
-            of the response. A limit of 0 (default) will fetch all
-            available data.
-        page_token: Token to fetch the subsequent page of results.
-            The value is obtained from the 'X-Rune-Next-Page-Token'
-            response header field.
-        timestamp: Optional enum "unix", "unixns", or "iso", which determines
-            how timestamps are formatted in the response
-        timezone: Optional timezone offset, in seconds, used to calculate
-            string-based timestamp formats such as datetime and iso.
-            For example, PST (UTC-0800) is represented as -28800.
-            If omitted, the timezone is UTC.
-        translate_enums: If True, enum values are returned as their string
-            representation. Otherwise, enums are returned as integer values.
-        client: If specified, this client is used to fetch data from the
-            API. Otherwise, the global StreamClient is used.
-
-    """
-    params = {
-        'stream_id': stream_id,
-        'start_time': start_time,
-        'start_time_ns': start_time_ns,
-        'end_time': end_time,
-        'end_time_ns': end_time_ns,
-        'format': 'json',
-        'limit': limit,
-        'page_token': page_token,
-        'timestamp': timestamp,
-        'timezone': timezone,
-        'translate_enums': translate_enums,
-        'client': client,
-    }
-    return get_stream_data(**params)
+    yield from client.get_data(
+        path,
+        start_time=start_time,
+        start_time_ns=start_time_ns,
+        end_time=end_time,
+        end_time_ns=end_time_ns,
+        format=format,
+        limit=limit,
+        page_token=page_token,
+        timestamp=timestamp,
+        timezone=timezone,
+        translate_enums=translate_enums,
+    )
 
 
 def get_stream_availability(
-    stream_id: Union[str, List[str]],
+    stream_ids: Union[str, List[str]],
     start_time: Union[float, datetime.date],
     end_time: Union[float, datetime.date],
     resolution: int,
@@ -225,39 +108,48 @@ def get_stream_availability(
     timestamp: Optional[str] = 'iso',
     timezone: Optional[int] = None,
     client: Optional[StreamClient] = None
-) -> Iterator[str]:
+) -> Iterator[Union[str, dict]]:
     """
-    Get the stream availability with the specified ID.
-    batch_operation must be specified if len(stream_ids) > 1.
+    Fetch the availability of 1 or multiple streams. When multiple stream
+    IDs are specified, this fetches the availability of **all** or **any**
+    of the streams (depending on the **batch_operation**).
 
     Args:
-        stream_id: ID of the stream
+        stream_ids: 1 or multiple stream IDs. If multiple stream IDs are
+            specified, **batch_operation** is also required.
         start_time: Start time for the query, provided as a unix timestamp
-                (in seconds) or a datetime.date.
+            (in seconds) or a datetime.date.
         end_time: End time for the query, provided as a unix timestamp
             (in seconds) or a datetime.date.
         resolution: Interval between returned timestamps, in seconds.
         batch_operation: Either "any" or "all", which determines
-            what type of batch calculation will determine availability for the
-            batch of streams. Availability values will equal 1 when
+            what type of batch calculation will determine availability for
+            multiple streams. Availability values will equal 1 when
             data is available for "all" or "any" of the requested streams in
             the given interval.
-        format: Optional enum "json" or "csv", which determines the content
-            type of the response
+            This argument is required when multiple **stream_ids** are specified.
+        format: Either "csv" (default) or "json". Determines the content type
+            of the API response.
         limit: Maximum number of timestamps to return, across *all pages*
             of the response. A limit of 0 (default) will fetch all
             available data.
         page_token: Token to fetch the subsequent page of results.
-            The value is obtained from the 'X-Rune-Next-Page-Token'
+            The value is obtained from the "X-Rune-Next-Page-Token"
             response header field.
-        timestamp: Optional enum "unix", "unixns", or "iso", which determines
+        timestamp: One of "unix", "unixns", or "iso", which determines
             how timestamps are formatted in the response
-        timezone: Optional timezone offset, in seconds, used to calculate
+        timezone: Timezone offset, in seconds, used to calculate
             string-based timestamp formats such as datetime and iso.
             For example, PST (UTC-0800) is represented as -28800.
             If omitted, the timezone is UTC.
         client: If specified, this client is used to fetch data from the
-            API. Otherwise, the global StreamClient is used.
+            API. Otherwise, the global :class:`~runeq.resources.client.StreamClient`
+            is used.
+
+    Returns:
+        An iterator over paginated API responses. If format is "json", each
+        response is a dict. If format is "csv", each response is a
+        CSV-formatted string.
 
     Raises:
         ValueError: if batch_operation is not specified and querying for
@@ -265,7 +157,6 @@ def get_stream_availability(
 
     """
     params = {
-        'stream_id': stream_id,
         'start_time': start_time,
         'end_time': end_time,
         'resolution': resolution,
@@ -283,137 +174,19 @@ def get_stream_availability(
         params['end_time'] = time.mktime(end_time.timetuple())
 
     client = client or global_stream_client()
-    stream_url = client.config.stream_url
 
-    if type(stream_id) is list:
+    if type(stream_ids) is str:
+        path = f"/v2/streams/{stream_ids}/availability"
+    elif type(stream_ids) is list and len(stream_ids) == 1:
+        path = f"/v2/streams/{stream_ids[0]}/availability"
+    else:
         # If querying for batch availability, need batch_operation
         if not batch_operation:
             raise ValueError(
-                "batch_operation must be specified if len(stream_id) > 1"
+                "batch_operation must be specified for multiple stream IDs"
             )
-        url = f"{stream_url}/v2/batch/availability"
-    else:
-        url = f"{stream_url}/v2/streams/{stream_id}/availability"
-        del params['stream_id']
 
-    yield from client.get_data(url, **params)
+        path = "/v2/batch/availability"
+        params["stream_id"] = stream_ids
 
-
-def get_stream_availability_csv(
-    stream_id: Union[str, List[str]],
-    start_time: Union[float, datetime.date],
-    end_time: Union[float, datetime.date],
-    resolution: int,
-    batch_operation: Optional[str] = None,
-    limit: Optional[int] = None,
-    page_token: Optional[str] = None,
-    timestamp: Optional[str] = 'iso',
-    timezone: Optional[int] = None,
-    client: Optional[StreamClient] = None
-) -> Iterator[str]:
-    """
-    Get the stream availability as a csv with the specified ID.
-    batch_operation must be specified if len(stream_ids) > 1.
-
-    Args:
-        stream_id: ID of the stream
-        start_time: Start time for the query, provided as a unix timestamp
-                (in seconds) or a datetime.date.
-        end_time: End time for the query, provided as a unix timestamp
-            (in seconds) or a datetime.date.
-        resolution: Interval between returned timestamps, in seconds.
-        batch_operation: Either "any" or "all", which determines
-            what type of batch calculation will determine availability for the
-            batch of streams. Availability values will equal 1 when
-            data is available for "all" or "any" of the requested streams in
-            the given interval.
-        limit: Maximum number of timestamps to return, across *all pages*
-            of the response. A limit of 0 (default) will fetch all
-            available data.
-        page_token: Token to fetch the subsequent page of results.
-            The value is obtained from the 'X-Rune-Next-Page-Token'
-            response header field.
-        timestamp: Optional enum "unix", "unixns", or "iso", which determines
-            how timestamps are formatted in the response
-        timezone: Optional timezone offset, in seconds, used to calculate
-            string-based timestamp formats such as datetime and iso.
-            For example, PST (UTC-0800) is represented as -28800.
-            If omitted, the timezone is UTC.
-        client: If specified, this client is used to fetch data from the
-            API. Otherwise, the global StreamClient is used.
-
-    """
-    params = {
-        'stream_id': stream_id,
-        'start_time': start_time,
-        'end_time': end_time,
-        'resolution': resolution,
-        'batch_operation': batch_operation,
-        'format': 'csv',
-        'limit': limit,
-        'page_token': page_token,
-        'timestamp': timestamp,
-        'timezone': timezone,
-        'client': client,
-    }
-    return get_stream_availability(**params)
-
-
-def get_stream_availability_json(
-    stream_id: Union[str, List[str]],
-    start_time: Union[float, datetime.date],
-    end_time: Union[float, datetime.date],
-    resolution: int,
-    batch_operation: Optional[str] = None,
-    limit: Optional[int] = None,
-    page_token: Optional[str] = None,
-    timestamp: Optional[str] = 'iso',
-    timezone: Optional[int] = None,
-    client: Optional[StreamClient] = None
-) -> Iterator[str]:
-    """
-    Get the stream availability as a json with the specified ID.
-    batch_operation must be specified if len(stream_ids) > 1.
-
-    Args:
-        stream_id: ID of the stream
-        start_time: Start time for the query, provided as a unix timestamp
-                (in seconds) or a datetime.date.
-        end_time: End time for the query, provided as a unix timestamp
-            (in seconds) or a datetime.date.
-        resolution: Interval between returned timestamps, in seconds.
-        batch_operation: Either "any" or "all", which determines
-            what type of batch calculation will determine availability for the
-            batch of streams. Availability values will equal 1 when
-            data is available for "all" or "any" of the requested streams in
-            the given interval.
-        limit: Maximum number of timestamps to return, across *all pages*
-            of the response. A limit of 0 (default) will fetch all
-            available data.
-        page_token: Token to fetch the subsequent page of results.
-            The value is obtained from the 'X-Rune-Next-Page-Token'
-            response header field.
-        timestamp: Optional enum "unix", "unixns", or "iso", which determines
-            how timestamps are formatted in the response
-        timezone: Optional timezone offset, in seconds, used to calculate
-            string-based timestamp formats such as datetime and iso.
-            For example, PST (UTC-0800) is represented as -28800.
-            If omitted, the timezone is UTC.
-        client: If specified, this client is used to fetch data from the
-            API. Otherwise, the global StreamClient is used.
-
-    """
-    params = {
-        'stream_id': stream_id,
-        'start_time': start_time,
-        'end_time': end_time,
-        'resolution': resolution,
-        'batch_operation': batch_operation,
-        'format': 'json',
-        'limit': limit,
-        'page_token': page_token,
-        'timestamp': timestamp,
-        'timezone': timezone,
-        'client': client,
-    }
-    return get_stream_availability(**params)
+    yield from client.get_data(path, **params)

--- a/runeq/resources/stream_metadata.py
+++ b/runeq/resources/stream_metadata.py
@@ -1,26 +1,24 @@
 """
-V2 SDK functionality to support Stream Metadata operations.
+Fetch metadata about streams, including stream types.
 
 """
-
 import datetime
 from io import StringIO
-
-import pandas as pd
 from typing import Callable, Iterable, Iterator, List, Optional, Type, Union
 
+import pandas as pd
 
 from .client import GraphClient, StreamClient, global_graph_client
 from .common import ItemBase, ItemSet
 from .patient import Device, Patient
-from .stream import (
-    get_stream_availability, get_stream_csv, get_stream_data, get_stream_json
-)
+from .stream import get_stream_availability, get_stream_data
+from runeq.errors import RuneError
 
 
 class Dimension(ItemBase):
     """
-    A dimension of a stream of data.
+    A dimension of a stream type. This is akin to a column in a table,
+    where each value in the timeseries is a row.
 
     """
     def __init__(
@@ -130,7 +128,7 @@ def get_all_stream_types(
     client: Optional[GraphClient] = None
 ) -> StreamTypeSet:
     """
-    Get a set of all stream types.
+    Get all stream types.
 
     Args:
         client: If specified, this client is used to fetch metadata from the
@@ -199,7 +197,8 @@ def _parse_stream_type(stream_type_attrs: dict) -> StreamType:
 
 class StreamMetadata(ItemBase):
     """
-    Stream metadata for a stream of timeseries data.
+    Metadata for a stream (i.e. timeseries data). This class also has methods
+    that fetch data for the stream.
 
     """
 
@@ -220,18 +219,19 @@ class StreamMetadata(ItemBase):
         Initialize with metadata.
 
         Args:
-            id: StreamMetadata ID
-            created_at: When the stream metadata was created (unix timestamp)
-            algorithm: Name of the ingestion process which converted the raw
-                dataset into various time series streams.
+            id: Stream ID
+            created_at: When the stream was created, as a Unix timestamp, as
+                a Unix timestamp (in seconds).
+            algorithm: A versioned label that describes the process that was
+                used to derive this timeseries.
             device_id: Device ID
             patient_id: Patient ID
-            stream_type: Stream type to categorize streams.
-            min_time: Unix float in seconds representing the start time of data
-                in the stream.
-            max_time: Unix float in seconds representing the end time of data
-                in the stream.
-            parameters: Key/Value pairs that label the stream.
+            stream_type: Stream type, which categorizes the stream data.
+            min_time: The earliest timestamp in the stream, as a Unix timestamp
+                (in seconds).
+            max_time: The latest timestamp in the stream, as a Unix timestamp
+                (in seconds).
+            parameters: Key/value pairs that label the stream.
 
         """
         self.created_at = created_at
@@ -265,19 +265,20 @@ class StreamMetadata(ItemBase):
         attrs["stream_type"] = self.stream_type.to_dict()
         return attrs
 
-    def iter_csv_responses(
+    def iter_stream_data(
         self,
         start_time: Optional[Union[float, datetime.date]] = None,
         start_time_ns: Optional[int] = None,
         end_time: Optional[Union[float, datetime.date]] = None,
         end_time_ns: Optional[int] = None,
+        format: Optional[str] = "csv",
         limit: Optional[int] = None,
         page_token: Optional[str] = None,
         timestamp: Optional[str] = "iso",
         timezone: Optional[int] = None,
         translate_enums: Optional[bool] = True,
         client: Optional[StreamClient] = None
-    ) -> Iterator[str]:
+    ) -> Iterator[Union[str, dict]]:
         """
         Iterate over CSV-formatted data for this stream.
 
@@ -290,99 +291,47 @@ class StreamMetadata(ItemBase):
                 (in seconds) or a datetime.date.
             end_time_ns: End time for the query, provided as a unix timestamp
                 (in nanoseconds).
+            format: Either "csv" (default) or "json". Determines the content
+                type of the API response, as well as the type that
+                is returned from this function.
             limit: Maximum number of timestamps to return, across *all pages*
                 of the response. A limit of 0 (default) will fetch all
                 available data.
             page_token: Token to fetch the subsequent page of results.
-                The value is obtained from the 'X-Rune-Next-Page-Token'
+                The value is obtained from the "X-Rune-Next-Page-Token"
                 response header field.
-            timestamp: Optional enum "unix", "unixns", or "iso", which
-                determines how timestamps are formatted in the response
-            timezone: Optional timezone offset, in seconds, used to calculate
+            timestamp: One of "unix", "unixns", or "iso", which determines
+                how timestamps are formatted in the response
+            timezone: Timezone offset, in seconds, used to calculate
                 string-based timestamp formats such as datetime and iso.
                 For example, PST (UTC-0800) is represented as -28800.
                 If omitted, the timezone is UTC.
             translate_enums: If True, enum values are returned as their string
-                representation. Otherwise, enums are returned as integer
-                values.
-            client: If specified, this client is used to fetch metadata from
-                the API. Otherwise, the global StreamClient is used.
+                representation. Otherwise, enums are returned as integer values.
+            client: If specified, this client is used to fetch data from the
+                API. Otherwise, the global
+                :class:`~runeq.resources.client.StreamClient` is used.
+
+        Returns:
+            An iterator over paginated API responses. If format is "json", each
+            response is a dict. If format is "csv", each response is a
+            CSV-formatted string.
 
         """
-        params = {
-            'stream_id': self.id,
-            'start_time': start_time,
-            'start_time_ns': start_time_ns,
-            'end_time': end_time,
-            'end_time_ns': end_time_ns,
-            'limit': limit,
-            'page_token': page_token,
-            'timestamp': timestamp,
-            'timezone': timezone,
-            'translate_enums': translate_enums,
-            'client': client,
-        }
-        return get_stream_csv(**params)
-
-    def iter_json_responses(
-        self,
-        start_time: Optional[Union[float, datetime.date]] = None,
-        start_time_ns: Optional[int] = None,
-        end_time: Optional[Union[float, datetime.date]] = None,
-        end_time_ns: Optional[int] = None,
-        limit: Optional[int] = None,
-        page_token: Optional[str] = None,
-        timestamp: Optional[str] = "iso",
-        timezone: Optional[int] = None,
-        translate_enums: Optional[bool] = True,
-        client: Optional[StreamClient] = None
-    ) -> Iterator[str]:
-        """
-        Iterate over JSON-formatted API responses for this stream
-
-        Args:
-            start_time: Start time for the query, provided as a unix timestamp
-                (in seconds) or a datetime.date.
-            start_time_ns: Start time for the query, provided as a unix
-                timestamp (in nanoseconds).
-            end_time: End time for the query, provided as a unix timestamp
-                (in seconds) or a datetime.date.
-            end_time_ns: End time for the query, provided as a unix timestamp
-                (in nanoseconds).format: Optional enum "json" or "csv", which
-                determines the content type of the response
-            limit: Maximum number of timestamps to return, across *all pages*
-                of the response. A limit of 0 (default) will fetch all
-                available data.
-            page_token: Token to fetch the subsequent page of results.
-                The value is obtained from the 'X-Rune-Next-Page-Token'
-                response header field.
-            timestamp: Optional enum "unix", "unixns", or "iso", which
-                determines how timestamps are formatted in the response
-            timezone: Optional timezone offset, in seconds, used to calculate
-                string-based timestamp formats such as datetime and iso.
-                For example, PST (UTC-0800) is represented as -28800.
-                If omitted, the timezone is UTC.
-            translate_enums: If True, enum values are returned as their string
-                representation. Otherwise, enums are returned as integer
-                values.
-            client: If specified, this client is used to fetch metadata from
-                the API. Otherwise, the global StreamClient is used.
-
-        """
-        params = {
-            'stream_id': self.id,
-            'start_time': start_time,
-            'start_time_ns': start_time_ns,
-            'end_time': end_time,
-            'end_time_ns': end_time_ns,
-            'limit': limit,
-            'page_token': page_token,
-            'timestamp': timestamp,
-            'timezone': timezone,
-            'translate_enums': translate_enums,
-            'client': client,
-        }
-        return get_stream_json(**params)
+        return get_stream_data(
+            stream_id=self.id,
+            start_time=start_time,
+            start_time_ns=start_time_ns,
+            end_time=end_time,
+            end_time_ns=end_time_ns,
+            format=format,
+            limit=limit,
+            page_token=page_token,
+            timestamp=timestamp,
+            timezone=timezone,
+            translate_enums=translate_enums,
+            client=client,
+        )
 
     def get_stream_dataframe(
         self,
@@ -398,7 +347,10 @@ class StreamMetadata(ItemBase):
         stream_client: Optional[StreamClient] = None
     ) -> pd.DataFrame:
         """
-        Get stream as enriched dataframe with stream data and metadata.
+        Get stream data as an enriched Pandas dataframe. In addition to the raw
+        stream data, the dataframe also includes columns with stream metadata.
+        This allows for the concatenation of dataframes with data from
+        multiple streams.
 
         Args:
             start_time: Start time for the query, provided as a unix timestamp
@@ -456,10 +408,10 @@ class StreamMetadata(ItemBase):
         all_stream_dfs = []
         for resp in get_stream_data(client=stream_client, **params):
             all_stream_dfs.append(pd.read_csv(StringIO(resp), sep=","))
+
         stream_df = pd.concat(all_stream_dfs, axis=0, ignore_index=True)
 
         return stream_df.assign(**metadata)
-
 
     def get_stream_availability_dataframe(
         self,
@@ -473,8 +425,9 @@ class StreamMetadata(ItemBase):
         stream_client: Optional[StreamClient] = None
     ) -> pd.DataFrame:
         """
-        Get stream availability as enriched dataframe with stream data
-        and metadata.
+        Get stream availability as an enriched Pandas dataframe. The dataframe
+        includes columns with metadata for this stream. This allows for the
+        concatenation of dataframes with availability for multiple streams.
 
         Args:
             start_time: Start time for the query, provided as a unix timestamp
@@ -508,21 +461,23 @@ class StreamMetadata(ItemBase):
         del metadata['max_time']
         del metadata['parameters']
 
-        params = {
-            'stream_id': metadata['stream_id'],
-            'start_time': start_time,
-            'end_time': end_time,
-            'resolution': resolution,
-            'format': 'csv',
-            'limit': limit,
-            'page_token': page_token,
-            'timestamp': timestamp,
-            'timezone': timezone,
-        }
+        responses = get_stream_availability(
+            stream_ids=metadata['stream_id'],
+            start_time=start_time,
+            end_time=end_time,
+            resolution=resolution,
+            format='csv',
+            limit=limit,
+            page_token=page_token,
+            timestamp=timestamp,
+            timezone=timezone,
+            client=stream_client,
+        )
 
         all_stream_dfs = []
-        for resp in get_stream_availability(client=stream_client, **params):
+        for resp in responses:
             all_stream_dfs.append(pd.read_csv(StringIO(resp), sep=","))
+
         stream_df = pd.concat(all_stream_dfs, axis=0, ignore_index=True)
 
         return stream_df.assign(**metadata)
@@ -563,19 +518,20 @@ class StreamMetadataSet(ItemSet):
     ) -> 'StreamMetadataSet':
         """
         Filters streams for those that match ALL optional filter parameters.
+        Returns a new StreamMetadataSet.
 
         Args:
-            stream_id: ID of the stream
+            stream_id: Stream ID
             patient_id: Patient ID
             device_id: Device ID
-            stream_type_id: StreamType ID
-            algorithm: Name of the ingestion process which converted the raw
-                dataset into various time series streams.
+            stream_type_id: Stream type ID
+            algorithm: A versioned label that describes the process that was
+                used to derive this timeseries.
             category: A broad categorization of the data type (e.g. neural,
                 vitals, etc)
             measurement: A specific label for what is being measured
                 (e.g. heart_rate, step_count, etc).
-            filter_function: User defined filter function which accepts a
+            filter_function: User-defined filter function which accepts a
                 Stream as a single argument and returns a boolean indicating
                 whether to keep that stream.
 
@@ -621,7 +577,9 @@ class StreamMetadataSet(ItemSet):
         stream_client: Optional[StreamClient] = None
     ) -> pd.DataFrame:
         """
-        Get stream set as enriched dataframe with stream data and metadata.
+        Get raw data for all streams in the collection, as an enriched Pandas
+        dataframe. The dataframe includes columns with metadata for each
+        stream.
 
         Args:
             start_time: Start time for the query, provided as a unix timestamp
@@ -670,7 +628,7 @@ class StreamMetadataSet(ItemSet):
 
         return pd.concat(all_stream_dfs, axis=0, ignore_index=True)
 
-    def get_stream_availability_dataframe(
+    def get_batch_availability_dataframe(
         self,
         start_time: Union[float, datetime.date],
         end_time: Union[float, datetime.date],
@@ -683,7 +641,12 @@ class StreamMetadataSet(ItemSet):
         stream_client: Optional[StreamClient] = None
     ) -> pd.DataFrame:
         """
-        Get stream availability data as a dataframe.
+        Get stream availability data as a Pandas dataframe. Depending on the
+        specified **batch_operation**, this fetches the availability of **all**
+        or **any** of the streams in the collection.
+
+        If you want to gather the availability of each *individual* stream in a
+        dataframe, see get_stream_availability_dataframe()
 
         Args:
             start_time: Start time for the query, provided as a unix timestamp
@@ -712,39 +675,47 @@ class StreamMetadataSet(ItemSet):
                 from the API. Otherwise, the global StreamClient is used.
 
         """
-        params = {
-            'stream_id': self.ids(),
-            'start_time': start_time,
-            'end_time': end_time,
-            'resolution': resolution,
-            'batch_operation': batch_operation,
-            'format': 'csv',
-            'limit': limit,
-            'page_token': page_token,
-            'timestamp': timestamp,
-            'timezone': timezone,
-            'client': stream_client,
-        }
+        responses = get_stream_availability(
+            stream_ids=list(self.ids()),
+            start_time=start_time,
+            end_time=end_time,
+            resolution=resolution,
+            batch_operation=batch_operation,
+            format='csv',
+            limit=limit,
+            page_token=page_token,
+            timestamp=timestamp,
+            timezone=timezone,
+            client=stream_client,
+        )
 
         all_stream_dfs = []
-        for resp in get_stream_availability(**params):
+        for resp in responses:
             all_stream_dfs.append(pd.read_csv(StringIO(resp), sep=","))
+
         stream_df = pd.concat(all_stream_dfs, axis=0, ignore_index=True)
 
         return stream_df
 
 
 def get_stream_metadata(
-    stream_id: Union[str, List[str]],
+    stream_ids: Union[str, List[str]],
     client: Optional[GraphClient] = None
 ) -> Union[StreamMetadata, StreamMetadataSet]:
     """
     Get stream metadata for the specified stream_id(s).
 
     Args:
-        stream_id: ID of the stream or list of IDs
+        stream_ids: ID of the stream or list of IDs
         client: If specified, this client is used to fetch metadata from the
             API. Otherwise, the global GraphClient is used.
+
+    Returns:
+        StreamMetadata: if a single stream ID is specified
+        StreamMetadataSet: if multiple stream IDs are specified
+
+    Raises:
+        RuneError: if any of the stream IDs are not found
 
     """
     client = client or global_graph_client()
@@ -787,13 +758,15 @@ def get_stream_metadata(
     '''
     stream_set = StreamMetadataSet()
 
-    stream_ids = stream_id if type(stream_id) is list else [stream_id]
+    if type(stream_ids) is str:
+        stream_ids = [stream_ids]
 
     result = client.execute(
         statement=query,
         stream_ids=stream_ids,
     )
 
+    seen_stream_ids = set(stream_ids)
     stream_list = result.get("streamListByIds", {})
     for stream_attrs in stream_list.get("streams", []):
         stream_type = _parse_stream_type(stream_attrs["streamType"])
@@ -817,6 +790,16 @@ def get_stream_metadata(
         )
         stream_set.add(stream)
 
+        try:
+            seen_stream_ids.remove(stream.id)
+        except KeyError:
+            pass
+
+    if len(seen_stream_ids) > 0:
+        raise RuneError(
+            f"1+ stream ID(s) not found: {','.join(seen_stream_ids)}"
+        )
+
     if len(stream_set) == 1:
         return list(stream_set)[0]
 
@@ -834,24 +817,21 @@ def get_patient_stream_metadata(
     **parameters
 ) -> StreamMetadataSet:
     """
-    Get stream metadata for streams that match ALL optional filter parameters
-    for the specific patient_id.
+    Get stream metadata for streams that match ALL filter parameters. Only the
+    patient ID is required.
 
     Args:
         patient_id: Patient ID
         device_id: Device ID
-        stream_type_id: StreamType ID
-        algorithm: Name of the ingestion process which converted the raw
-            dataset into various time series streams.
+        stream_type_id: Stream type ID
+        algorithm: A versioned label that describes the process that was
+            used to derive this timeseries.
         category: A broad categorization of the data type (e.g. neural,
             vitals, etc)
         measurement: A specific label for what is being measured
             (e.g. heart_rate, step_count, etc).
         client: If specified, this client is used to fetch metadata from the
             API. Otherwise, the global GraphClient is used.
-
-    Raises:
-        ValueError: if the set does not contain an item with the ID.
 
     """
     client = client or global_graph_client()
@@ -897,7 +877,7 @@ def get_patient_stream_metadata(
     if device_id:
         device_id = Device.denormalize_id(patient_id, device_id)
 
-    # Add cateogory to params and format params list for filter query
+    # Add category to params and format params list for filter query
     if category:
         parameters["category"] = category
 
@@ -965,7 +945,7 @@ def get_patient_stream_metadata(
 
 
 def get_stream_dataframe(
-    stream_id: Union[str, List[str]],
+    stream_ids: Union[str, List[str]],
     start_time: Optional[Union[float, datetime.date]] = None,
     start_time_ns: Optional[int] = None,
     end_time: Optional[Union[float, datetime.date]] = None,
@@ -982,7 +962,7 @@ def get_stream_dataframe(
     Get stream(s) as enriched dataframe with stream data and metadata.
 
     Args:
-        stream_id: ID of the stream or list of IDs
+        stream_ids: 1 or multiple stream IDs
         start_time: Start time for the query, provided as a unix timestamp
                 (in seconds) or a datetime.date.
         start_time_ns: Start time for the query, provided as a unix timestamp
@@ -1012,11 +992,11 @@ def get_stream_dataframe(
             the API. Otherwise, the global GraphClient is used.
 
     Raises:
-        RuneError: if recieved more than 1 metadata for specified stream_id.
+        RuneError: if any of the stream IDs is not found.
 
     """
     stream_meta_set = get_stream_metadata(
-        stream_id=stream_id,
+        stream_ids=stream_ids,
         client=graph_client
     )
 
@@ -1035,7 +1015,7 @@ def get_stream_dataframe(
 
 
 def get_stream_availability_dataframe(
-    stream_id: Union[str, List[str]],
+    stream_ids: Union[str, List[str]],
     start_time: Union[float, datetime.date],
     end_time: Union[float, datetime.date],
     resolution: int,
@@ -1049,11 +1029,15 @@ def get_stream_availability_dataframe(
 ) -> pd.DataFrame:
     """
     Get stream availability data as a dataframe. If a single stream_id is
-    passed in, the dataframe will be enriched with the stream's metadata,
-    otherwise it will contain just the availability data.
+    passed in, the dataframe will be enriched with the stream's metadata.
+    Otherwise it will contain just the availability data.
+
+    Note that this is different from the get_stream_availability_dataframe
+    method on the :class:`~runeq.resources.stream_metadata.StreamMetadataSet`.
+    This dataframe contains the availability of each *individual* stream.
 
     Args:
-        stream_id: ID of the stream or list of IDs
+        stream_ids: 1 or multiple stream IDs
         start_time: Start time for the query, provided as a unix timestamp
                 (in seconds) or a datetime.date.
         end_time: End time for the query, provided as a unix timestamp
@@ -1081,30 +1065,28 @@ def get_stream_availability_dataframe(
         graph_client: If specified, this client is used to fetch metadata from
             the API. Otherwise, the global GraphClient is used.
 
-    Raises:
-        RuneError: if recieved more than 1 metadata for specified stream_id.
-
     """
     # If there are multiple stream ids, there is no need to get metadata
     # since the dataframe response will be simplified
-    if type(stream_id) is list and len(stream_id) > 1:
-        params = {
-            'stream_id': stream_id,
-            'start_time': start_time,
-            'end_time': end_time,
-            'resolution': resolution,
-            'batch_operation': batch_operation,
-            'format': 'csv',
-            'limit': limit,
-            'page_token': page_token,
-            'timestamp': timestamp,
-            'timezone': timezone,
-            'client': stream_client,
-        }
+    if type(stream_ids) is list and len(stream_ids) > 1:
+        responses = get_stream_availability(
+            stream_ids=stream_ids,
+            start_time=start_time,
+            end_time=end_time,
+            resolution=resolution,
+            batch_operation=batch_operation,
+            format='csv',
+            limit=limit,
+            page_token=page_token,
+            timestamp=timestamp,
+            timezone=timezone,
+            client=stream_client,
+        )
 
         all_stream_dfs = []
-        for resp in get_stream_availability(**params):
+        for resp in responses:
             all_stream_dfs.append(pd.read_csv(StringIO(resp), sep=","))
+
         stream_df = pd.concat(all_stream_dfs, axis=0, ignore_index=True)
 
         return stream_df
@@ -1112,19 +1094,17 @@ def get_stream_availability_dataframe(
     # Since there is only one stream id, we can enrich the dataframe with
     # metadata
     stream_meta = get_stream_metadata(
-        stream_id=stream_id,
+        stream_ids=stream_ids,
         client=graph_client
     )
 
-    params = {
-        'start_time': start_time,
-        'end_time': end_time,
-        'resolution': resolution,
-        'limit': limit,
-        'page_token': page_token,
-        'timestamp': timestamp,
-        'timezone': timezone,
-        'stream_client': stream_client,
-    }
-
-    return stream_meta.get_stream_availability_dataframe(**params)
+    return stream_meta.get_stream_availability_dataframe(
+        start_time=start_time,
+        end_time=end_time,
+        resolution=resolution,
+        limit=limit,
+        page_token=page_token,
+        timestamp=timestamp,
+        timezone=timezone,
+        stream_client=stream_client,
+    )

--- a/runeq/resources/stream_metadata.py
+++ b/runeq/resources/stream_metadata.py
@@ -307,7 +307,8 @@ class StreamMetadata(ItemBase):
                 For example, PST (UTC-0800) is represented as -28800.
                 If omitted, the timezone is UTC.
             translate_enums: If True, enum values are returned as their string
-                representation. Otherwise, enums are returned as integer values.
+                representation. Otherwise, enums are returned as integer
+                values.
             client: If specified, this client is used to fetch data from the
                 API. Otherwise, the global
                 :class:`~runeq.resources.client.StreamClient` is used.

--- a/runeq/resources/stream_metadata.py
+++ b/runeq/resources/stream_metadata.py
@@ -677,7 +677,7 @@ class StreamMetadataSet(ItemSet):
 
         """
         responses = get_stream_availability(
-            stream_ids=list(self.ids()),
+            stream_ids=self.ids(),
             start_time=start_time,
             end_time=end_time,
             resolution=resolution,
@@ -700,7 +700,7 @@ class StreamMetadataSet(ItemSet):
 
 
 def get_stream_metadata(
-    stream_ids: Union[str, List[str]],
+    stream_ids: Union[str, Iterable[str]],
     client: Optional[GraphClient] = None
 ) -> Union[StreamMetadata, StreamMetadataSet]:
     """
@@ -761,6 +761,8 @@ def get_stream_metadata(
 
     if type(stream_ids) is str:
         stream_ids = [stream_ids]
+    else:
+        stream_ids = list(stream_ids)
 
     result = client.execute(
         statement=query,
@@ -946,7 +948,7 @@ def get_patient_stream_metadata(
 
 
 def get_stream_dataframe(
-    stream_ids: Union[str, List[str]],
+    stream_ids: Union[str, Iterable[str]],
     start_time: Optional[Union[float, datetime.date]] = None,
     start_time_ns: Optional[int] = None,
     end_time: Optional[Union[float, datetime.date]] = None,
@@ -1016,7 +1018,7 @@ def get_stream_dataframe(
 
 
 def get_stream_availability_dataframe(
-    stream_ids: Union[str, List[str]],
+    stream_ids: Union[str, Iterable[str]],
     start_time: Union[float, datetime.date],
     end_time: Union[float, datetime.date],
     resolution: int,
@@ -1067,6 +1069,10 @@ def get_stream_availability_dataframe(
             the API. Otherwise, the global GraphClient is used.
 
     """
+    # Standardize iterable stream_ids to a list (so that we can use len)
+    if type(stream_ids) is not str:
+        stream_ids = list(stream_ids)
+
     # If there are multiple stream ids, there is no need to get metadata
     # since the dataframe response will be simplified
     if type(stream_ids) is list and len(stream_ids) > 1:

--- a/tests/resources/test_stream.py
+++ b/tests/resources/test_stream.py
@@ -5,11 +5,8 @@ Tests for the V2 SDK Stream.
 from unittest import TestCase, mock
 
 from runeq.config import Config
-from runeq.resources.client import GraphClient
-from runeq.resources.stream import (
-    get_stream_availability, get_stream_availability_csv,
-    get_stream_availability_json, get_stream_csv, get_stream_json
-)
+from runeq.resources.client import StreamClient
+from runeq.resources.stream import get_stream_availability, get_stream_data
 
 
 class TestStreamData(TestCase):
@@ -23,7 +20,7 @@ class TestStreamData(TestCase):
         Set up mock graph client for testing.
 
         """
-        self.mock_client = GraphClient(
+        self.mock_client = StreamClient(
             Config(
                 client_key_id='test',
                 client_access_key='config'
@@ -46,6 +43,7 @@ class TestStreamData(TestCase):
 2022-07-28T14:26:45.362149Z,0.024860087782144547,20000000
 2022-07-28T14:26:45.36221Z,0.026072751730680466,20000000"""
 
+        # TODO: make sure client.get_data does response format...!
         self.mock_client.get_data = mock.Mock()
         self.mock_client.get_data.return_value = iter(
             [
@@ -54,7 +52,7 @@ class TestStreamData(TestCase):
             ]
         )
 
-        stream = get_stream_csv('test_stream_id', client=self.mock_client)
+        stream = get_stream_data('test_stream_id', client=self.mock_client)
 
         expected = [expected_data, expected_data]
         actual = list(stream)
@@ -66,47 +64,47 @@ class TestStreamData(TestCase):
         parameters.
 
         """
-        expected_data = """{
-   "cardinality":10,
-   "data":{
-      "acceleration":[
-         0.020525138825178146,
-         0.020834974944591522,
-         0.021182861179113388,
-         0.022172993049025536,
-         0.02356025017797947,
-         0.024860087782144547,
-         0.026072751730680466,
-         0.027338741347193718,
-         0.028795091435313225,
-         0.029819512739777565
-      ],
-      "measurement_duration_ns":[
-         20000000,
-         20000000,
-         20000000,
-         20000000,
-         20000000,
-         20000000,
-         20000000,
-         20000000,
-         20000000,
-         20000000
-      ],
-      "time":[
-         "2022-07-28T14:26:45.167568Z",
-         "2022-07-28T14:26:45.361596Z",
-         "2022-07-28T14:26:45.361796Z",
-         "2022-07-28T14:26:45.3618588Z",
-         "2022-07-28T14:26:45.3620749Z",
-         "2022-07-28T14:26:45.362149Z",
-         "2022-07-28T14:26:45.36221Z",
-         "2022-07-28T14:26:45.362269Z",
-         "2022-07-28T14:26:45.36234Z",
-         "2022-07-28T14:26:45.3624Z"
-      ]
-   }
-}"""
+        expected_data = {
+            "cardinality": 10,
+            "data": {
+                "acceleration": [
+                    0.020525138825178146,
+                    0.020834974944591522,
+                    0.021182861179113388,
+                    0.022172993049025536,
+                    0.02356025017797947,
+                    0.024860087782144547,
+                    0.026072751730680466,
+                    0.027338741347193718,
+                    0.028795091435313225,
+                    0.029819512739777565
+                ],
+                "measurement_duration_ns": [
+                    20000000,
+                    20000000,
+                    20000000,
+                    20000000,
+                    20000000,
+                    20000000,
+                    20000000,
+                    20000000,
+                    20000000,
+                    20000000
+                ],
+                "time": [
+                    "2022-07-28T14:26:45.167568Z",
+                    "2022-07-28T14:26:45.361596Z",
+                    "2022-07-28T14:26:45.361796Z",
+                    "2022-07-28T14:26:45.3618588Z",
+                    "2022-07-28T14:26:45.3620749Z",
+                    "2022-07-28T14:26:45.362149Z",
+                    "2022-07-28T14:26:45.36221Z",
+                    "2022-07-28T14:26:45.362269Z",
+                    "2022-07-28T14:26:45.36234Z",
+                    "2022-07-28T14:26:45.3624Z"
+                ]
+            }
+        }
 
         self.mock_client.get_data = mock.Mock()
         self.mock_client.get_data.return_value = iter(
@@ -116,7 +114,11 @@ class TestStreamData(TestCase):
             ]
         )
 
-        stream = get_stream_json('test_stream_id', client=self.mock_client)
+        stream = get_stream_data(
+            'test_stream_id',
+            format="json",
+            client=self.mock_client,
+        )
 
         expected = [expected_data, expected_data]
         actual = list(stream)
@@ -145,11 +147,12 @@ class TestStreamData(TestCase):
             ]
         )
 
-        availability = get_stream_availability_csv(
-            stream_id='test_stream_id',
+        availability = get_stream_availability(
+            stream_ids='test_stream_id',
             start_time=123,
             end_time=345,
             resolution=300,
+            format="csv",
             client=self.mock_client
         )
 
@@ -162,37 +165,36 @@ class TestStreamData(TestCase):
         Test get a stream availability as json for a specific stream_id.
 
         """
-        expected_data = """{
-   "data":{
-      "time":[
-         "2022-07-28T14:25:00Z",
-         "2022-07-28T14:30:00Z",
-         "2022-07-28T14:35:00Z",
-         "2022-07-28T14:40:00Z",
-         "2022-07-28T14:45:00Z",
-         "2022-07-28T14:50:00Z",
-         "2022-07-28T14:55:00Z",
-         "2022-07-28T15:00:00Z",
-         "2022-07-28T15:05:00Z",
-         "2022-07-28T15:10:00Z"
-      ],
-      "availability":[
-         1,
-         1,
-         0,
-         0,
-         1,
-         1,
-         0,
-         1,
-         1,
-         1
-      ]
-   },
-   "approx_available_duration_s":3000,
-   "cardinality":10
-}
-"""
+        expected_data = {
+            "data": {
+                "time": [
+                    "2022-07-28T14:25:00Z",
+                    "2022-07-28T14:30:00Z",
+                    "2022-07-28T14:35:00Z",
+                    "2022-07-28T14:40:00Z",
+                    "2022-07-28T14:45:00Z",
+                    "2022-07-28T14:50:00Z",
+                    "2022-07-28T14:55:00Z",
+                    "2022-07-28T15:00:00Z",
+                    "2022-07-28T15:05:00Z",
+                    "2022-07-28T15:10:00Z"
+                ],
+                "availability": [
+                    1,
+                    1,
+                    0,
+                    0,
+                    1,
+                    1,
+                    0,
+                    1,
+                    1,
+                    1
+                ]
+            },
+            "approx_available_duration_s": 3000,
+            "cardinality": 10
+        }
 
         self.mock_client.get_data = mock.Mock()
         self.mock_client.get_data.return_value = iter(
@@ -202,11 +204,12 @@ class TestStreamData(TestCase):
             ]
         )
 
-        availability = get_stream_availability_json(
-            stream_id='test_stream_id',
+        availability = get_stream_availability(
+            stream_ids='test_stream_id',
             start_time=123,
             end_time=345,
             resolution=300,
+            format="json",
             client=self.mock_client
         )
 
@@ -243,15 +246,16 @@ class TestStreamData(TestCase):
             "batch_operation must be specified"
         ):
             get_stream_availability(
-                stream_id=['test_stream_id1', 'test_stream_id2'],
+                stream_ids=['test_stream_id1', 'test_stream_id2'],
                 start_time=123,
                 end_time=345,
                 resolution=300,
+                format="csv",
                 client=self.mock_client
             ).__next__()
 
         availability = get_stream_availability(
-            stream_id=['test_stream_id1', 'test_stream_id2'],
+            stream_ids=['test_stream_id1', 'test_stream_id2'],
             start_time=123,
             end_time=345,
             resolution=300,

--- a/tests/resources/test_stream.py
+++ b/tests/resources/test_stream.py
@@ -20,7 +20,7 @@ class TestStreamData(TestCase):
         Set up mock graph client for testing.
 
         """
-        self.stream_client, = StreamClient(
+        self.stream_client = StreamClient(
             Config(
                 client_key_id='test',
                 client_access_key='config'

--- a/tests/resources/test_stream.py
+++ b/tests/resources/test_stream.py
@@ -20,7 +20,7 @@ class TestStreamData(TestCase):
         Set up mock graph client for testing.
 
         """
-        self.mock_client = StreamClient(
+        self.stream_client, = StreamClient(
             Config(
                 client_key_id='test',
                 client_access_key='config'
@@ -28,7 +28,8 @@ class TestStreamData(TestCase):
         )
         self.maxDiff = None
 
-    def test_get_stream_data_csv(self):
+    @mock.patch("runeq.resources.client.requests")
+    def test_get_stream_data_csv(self, mock_requests):
         """
         Test get a stream as csv with specific stream_id and optional
         parameters.
@@ -43,22 +44,32 @@ class TestStreamData(TestCase):
 2022-07-28T14:26:45.362149Z,0.024860087782144547,20000000
 2022-07-28T14:26:45.36221Z,0.026072751730680466,20000000"""
 
-        # TODO: make sure client.get_data does response format...!
-        self.mock_client.get_data = mock.Mock()
-        self.mock_client.get_data.return_value = iter(
-            [
-                expected_data,
-                expected_data
-            ]
-        )
+        # Mock a paginated response
+        mock_response1 = mock.Mock()
+        mock_response1.ok = True
+        mock_response1.headers = {
+            "X-Rune-Next-Page-Token": "foobar"
+        }
+        mock_response1.text = expected_data
 
-        stream = get_stream_data('test_stream_id', client=self.mock_client)
+        mock_response2 = mock.Mock()
+        mock_response2.ok = True
+        mock_response2.headers = {}
+        mock_response2.text = expected_data
+
+        mock_requests.get.side_effect = [
+            mock_response1,
+            mock_response2
+        ]
+
+        stream = get_stream_data('test_stream_id', client=self.stream_client,)
 
         expected = [expected_data, expected_data]
         actual = list(stream)
         self.assertEqual(expected, actual)
 
-    def test_get_stream_data_json(self):
+    @mock.patch("runeq.resources.client.requests")
+    def test_get_stream_data_json(self, mock_requests):
         """
         Test get a stream as json with specific stream_id and optional
         parameters.
@@ -106,25 +117,36 @@ class TestStreamData(TestCase):
             }
         }
 
-        self.mock_client.get_data = mock.Mock()
-        self.mock_client.get_data.return_value = iter(
-            [
-                expected_data,
-                expected_data
-            ]
-        )
+        # Mock a paginated response
+        mock_response1 = mock.Mock()
+        mock_response1.ok = True
+        mock_response1.headers = {
+            "X-Rune-Next-Page-Token": "foobar"
+        }
+        mock_response1.json.return_value = expected_data
+
+        mock_response2 = mock.Mock()
+        mock_response2.ok = True
+        mock_response2.headers = {}
+        mock_response2.json.return_value = expected_data
+
+        mock_requests.get.side_effect = [
+            mock_response1,
+            mock_response2
+        ]
 
         stream = get_stream_data(
             'test_stream_id',
             format="json",
-            client=self.mock_client,
+            client=self.stream_client,,
         )
 
         expected = [expected_data, expected_data]
         actual = list(stream)
         self.assertEqual(expected, actual)
 
-    def test_get_stream_availability_csv(self):
+    @mock.patch("runeq.resources.client.requests")
+    def test_get_stream_availability_csv(self, mock_requests):
         """
         Test get a stream availability as csv for a specific stream_id.
 
@@ -139,13 +161,23 @@ class TestStreamData(TestCase):
 2022-07-28T14:26:45.36221Z,1
 """
 
-        self.mock_client.get_data = mock.Mock()
-        self.mock_client.get_data.return_value = iter(
-            [
-                expected_data,
-                expected_data
-            ]
-        )
+        # Mock a paginated response
+        mock_response1 = mock.Mock()
+        mock_response1.ok = True
+        mock_response1.headers = {
+            "X-Rune-Next-Page-Token": "foobar"
+        }
+        mock_response1.text = expected_data
+
+        mock_response2 = mock.Mock()
+        mock_response2.ok = True
+        mock_response2.headers = {}
+        mock_response2.text = expected_data
+
+        mock_requests.get.side_effect = [
+            mock_response1,
+            mock_response2
+        ]
 
         availability = get_stream_availability(
             stream_ids='test_stream_id',
@@ -153,14 +185,15 @@ class TestStreamData(TestCase):
             end_time=345,
             resolution=300,
             format="csv",
-            client=self.mock_client
+            client=self.stream_client,
         )
 
         expected = [expected_data, expected_data]
         actual = list(availability)
         self.assertEqual(expected, actual)
 
-    def test_get_stream_availability_json(self):
+    @mock.patch("runeq.resources.client.requests")
+    def test_get_stream_availability_json(self, mock_requests):
         """
         Test get a stream availability as json for a specific stream_id.
 
@@ -196,13 +229,23 @@ class TestStreamData(TestCase):
             "cardinality": 10
         }
 
-        self.mock_client.get_data = mock.Mock()
-        self.mock_client.get_data.return_value = iter(
-            [
-                expected_data,
-                expected_data
-            ]
-        )
+        # Mock a paginated response
+        mock_response1 = mock.Mock()
+        mock_response1.ok = True
+        mock_response1.headers = {
+            "X-Rune-Next-Page-Token": "foobar"
+        }
+        mock_response1.json.return_value = expected_data
+
+        mock_response2 = mock.Mock()
+        mock_response2.ok = True
+        mock_response2.headers = {}
+        mock_response2.json.return_value = expected_data
+
+        mock_requests.get.side_effect = [
+            mock_response1,
+            mock_response2
+        ]
 
         availability = get_stream_availability(
             stream_ids='test_stream_id',
@@ -210,14 +253,15 @@ class TestStreamData(TestCase):
             end_time=345,
             resolution=300,
             format="json",
-            client=self.mock_client
+            client=self.stream_client,
         )
 
         expected = [expected_data, expected_data]
         actual = list(availability)
         self.assertEqual(expected, actual)
 
-    def test_get_batch_stream_availability(self):
+    @mock.patch("runeq.resources.client.requests")
+    def test_get_batch_stream_availability(self, mock_requests):
         """
         Test get batch stream availability for multiple stream_ids.
 
@@ -232,13 +276,23 @@ class TestStreamData(TestCase):
 2022-07-28T14:26:45.36221Z,1
 """
 
-        self.mock_client.get_data = mock.Mock()
-        self.mock_client.get_data.return_value = iter(
-            [
-                expected_data,
-                expected_data
-            ]
-        )
+        # Mock a paginated response
+        mock_response1 = mock.Mock()
+        mock_response1.ok = True
+        mock_response1.headers = {
+            "X-Rune-Next-Page-Token": "foobar"
+        }
+        mock_response1.text = expected_data
+
+        mock_response2 = mock.Mock()
+        mock_response2.ok = True
+        mock_response2.headers = {}
+        mock_response2.text = expected_data
+
+        mock_requests.get.side_effect = [
+            mock_response1,
+            mock_response2
+        ]
 
         # Must include batch_operation when querying >1 stream
         with self.assertRaisesRegex(
@@ -251,7 +305,7 @@ class TestStreamData(TestCase):
                 end_time=345,
                 resolution=300,
                 format="csv",
-                client=self.mock_client
+                client=self.stream_client,
             ).__next__()
 
         availability = get_stream_availability(
@@ -260,7 +314,7 @@ class TestStreamData(TestCase):
             end_time=345,
             resolution=300,
             batch_operation="all",
-            client=self.mock_client
+            client=self.stream_client,
         )
 
         expected = [expected_data, expected_data]

--- a/tests/resources/test_stream.py
+++ b/tests/resources/test_stream.py
@@ -138,7 +138,7 @@ class TestStreamData(TestCase):
         stream = get_stream_data(
             'test_stream_id',
             format="json",
-            client=self.stream_client,,
+            client=self.stream_client,
         )
 
         expected = [expected_data, expected_data]

--- a/tests/resources/test_stream_metadata.py
+++ b/tests/resources/test_stream_metadata.py
@@ -347,7 +347,7 @@ class TestStreamMetadata(TestCase):
         ]
 
         streams = get_stream_metadata(
-            stream_id=["s1", "s2"],
+            stream_ids=["s1", "s2"],
             client=self.mock_graph_client
         )
 
@@ -922,7 +922,7 @@ class TestStreamMetadata(TestCase):
         ]
 
         stream_df = get_stream_dataframe(
-            stream_id="s1",
+            stream_ids="s1",
             stream_client=self.mock_stream_client,
             graph_client=self.mock_graph_client
         )
@@ -1145,7 +1145,7 @@ class TestStreamMetadata(TestCase):
         ]
 
         stream_df = get_stream_dataframe(
-            stream_id=["s1", "s2"],
+            stream_ids=["s1", "s2"],
             stream_client=self.mock_stream_client,
             graph_client=self.mock_graph_client
         )
@@ -1368,7 +1368,7 @@ class TestStreamMetadata(TestCase):
         ]
 
         stream_df = get_stream_availability_dataframe(
-            stream_id="s1",
+            stream_ids="s1",
             start_time=123,
             end_time=345,
             resolution=300,
@@ -1476,7 +1476,7 @@ class TestStreamMetadata(TestCase):
         )
 
         stream_df = get_stream_availability_dataframe(
-            stream_id=["s1", "s2"],
+            stream_ids=["s1", "s2"],
             start_time=123,
             end_time=345,
             resolution=300,


### PR DESCRIPTION
* Consolidating functions to fetch stream data, to eliminate thin CSV & JSON wrappers around stream-fetching functionality
* Updating the way requests are patched in tests -- I caught a bug in the way JSON responses were being iterated over
* When multiple stream IDs are accepted, I'd like to standardize the argument name to `stream_ids`, for better distinction from functions where only one ID is accepted.
     * As part of this change, I'm also moving away from using `**params` in functions calls, when it's just as easy to pass in arguments directly... This is largely for the convenience of syntax-highlighting (which helped me catch some places that I misnamed arguments)
* Adding/updating a lot of docstrings. Some of these changes may mess up the autogenerated docs -- I'm going to fix that (and add a quickstart & some other things) in a separate PR, because this one is already too big.