### PR TITLE
[DATA-481] Standardize name field; more compact __repr__

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,6 @@ jobs:
         steps:
             - checkout:
                 path: ~/runeq-python
-#            - restore_cache:
-#                key: runeq-python-<< parameters.executor >>-{{ checksum "requirements/common.txt" }}-{{ checksum "requirements/dev.txt" }}-{{ checksum "requirements/docs.txt" }}
             - run:
                 name: Install flake8
                 command: |
@@ -55,8 +53,6 @@ jobs:
         steps:
             - checkout:
                   path: ~/runeq-python
-#            - restore_cache:
-#                  key: runeq-python-<<parameters.executor>>-{{ checksum "requirements/common.txt" }}-{{ checksum "requirements/dev.txt" }}-{{ checksum "requirements/docs.txt" }}
             - run:
                   name: Install Dependencies
                   command: |
@@ -64,10 +60,6 @@ jobs:
                       . venv/bin/activate
                       pip install --upgrade pip
                       pip install -r requirements/dev.txt
-#            - save_cache:
-#                  key: runeq-python-<<parameters.executor>>-{{ checksum "requirements/common.txt" }}-{{ checksum "requirements/dev.txt" }}-{{ checksum "requirements/docs.txt" }}
-#                  paths:
-#                      - venv
             - run:
                   name: Run Tests and Coverage
                   command: |
@@ -92,8 +84,6 @@ jobs:
         steps:
             - checkout:
                 path: ~/runeq-python
-#            - restore_cache:
-#                key: runeq-python-<< parameters.executor >>-{{ checksum "requirements/common.txt" }}-{{ checksum "requirements/docs.txt" }}
             - run:
                 name: Install docs requirements
                 command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,8 @@ jobs:
         steps:
             - checkout:
                 path: ~/runeq-python
-            - restore_cache:
-                key: runeq-python-<< parameters.executor >>-{{ checksum "requirements/common.txt" }}-{{ checksum "requirements/dev.txt" }}-{{ checksum "requirements/docs.txt" }}
+#            - restore_cache:
+#                key: runeq-python-<< parameters.executor >>-{{ checksum "requirements/common.txt" }}-{{ checksum "requirements/dev.txt" }}-{{ checksum "requirements/docs.txt" }}
             - run:
                 name: Install flake8
                 command: |
@@ -55,8 +55,8 @@ jobs:
         steps:
             - checkout:
                   path: ~/runeq-python
-            - restore_cache:
-                  key: runeq-python-<<parameters.executor>>-{{ checksum "requirements/common.txt" }}-{{ checksum "requirements/dev.txt" }}-{{ checksum "requirements/docs.txt" }}
+#            - restore_cache:
+#                  key: runeq-python-<<parameters.executor>>-{{ checksum "requirements/common.txt" }}-{{ checksum "requirements/dev.txt" }}-{{ checksum "requirements/docs.txt" }}
             - run:
                   name: Install Dependencies
                   command: |
@@ -64,10 +64,10 @@ jobs:
                       . venv/bin/activate
                       pip install --upgrade pip
                       pip install -r requirements/dev.txt
-            - save_cache:
-                  key: runeq-python-<<parameters.executor>>-{{ checksum "requirements/common.txt" }}-{{ checksum "requirements/dev.txt" }}-{{ checksum "requirements/docs.txt" }}
-                  paths:
-                      - venv
+#            - save_cache:
+#                  key: runeq-python-<<parameters.executor>>-{{ checksum "requirements/common.txt" }}-{{ checksum "requirements/dev.txt" }}-{{ checksum "requirements/docs.txt" }}
+#                  paths:
+#                      - venv
             - run:
                   name: Run Tests and Coverage
                   command: |
@@ -92,8 +92,8 @@ jobs:
         steps:
             - checkout:
                 path: ~/runeq-python
-            - restore_cache:
-                key: runeq-python-<< parameters.executor >>-{{ checksum "requirements/common.txt" }}-{{ checksum "requirements/docs.txt" }}
+#            - restore_cache:
+#                key: runeq-python-<< parameters.executor >>-{{ checksum "requirements/common.txt" }}-{{ checksum "requirements/docs.txt" }}
             - run:
                 name: Install docs requirements
                 command: |

--- a/runeq/resources/common.py
+++ b/runeq/resources/common.py
@@ -144,18 +144,39 @@ class ItemSet(ABC):
             f"{self._item_class.__name__} with ID {id}"
         )
 
-    def add(self, *items: ItemBase):
+    def add(self, items: Union[ItemBase, Iterable[ItemBase]]):
         """
-        Add item(s) to this set.
+        Add item(s) to this set. Accepts a single item OR an interable of
+        items that have the same type as the item class (including another
+        ItemSet of this type).
 
         """
+        if type(items) is self._item_class:
+            items = [items]
+
         for item in items:
             if type(item) is not self._item_class:
                 raise TypeError(
-                    f'cannot add {str(item)}; must be type {self._item_class}'
+                    f'cannot add {str(item)}; must be type {self._item_class.__name__}'
                 )
 
             self._items[item.id] = item
+
+    def __add__(self, other: 'ItemSet'):
+        """
+        Add two ItemSets together, creating a new ItemSet of the same type.
+        Both ItemSets must have the same type.
+
+        """
+        if type(other) is not self.__class__:
+            raise TypeError(
+                f'cannot add {self.__class__.__name__} and {type(other).__name__}'
+            )
+
+        # Copy all the items from this set to a new one
+        new_set = self.__class__([item for item in self])
+        new_set.add(other)
+        return new_set
 
     def remove(self, *items: Union[str, ItemBase]):
         """

--- a/runeq/resources/common.py
+++ b/runeq/resources/common.py
@@ -144,41 +144,34 @@ class ItemSet(ABC):
             f"{self._item_class.__name__} with ID {id}"
         )
 
-    def add(self, items: Union[ItemBase, Iterable[ItemBase]]):
+    def add(self, item: ItemBase):
         """
-        Add item(s) to this set. Accepts a single item OR an interable of
-        items that have the same type as the item class (including another
-        ItemSet of this type).
+        Add a single item to the set. Must be the same type as other members
+        of the collection
 
         """
-        if type(items) is self._item_class:
-            items = [items]
+        if type(item) is not self._item_class:
+            raise TypeError(
+                f'cannot add {str(item)}; must be type '
+                f'{self._item_class.__name__}'
+            )
 
+        self._items[item.id] = item
+
+    def update(self, items: Iterable[ItemBase]):
+        """
+        Add an iterable of item(s) to this set. All items must be the same
+        class as members of this collection.
+
+        """
         for item in items:
             if type(item) is not self._item_class:
                 raise TypeError(
-                    f'cannot add {str(item)}; must be type '
+                    f'cannot update with {str(item)}; all items must be type '
                     f'{self._item_class.__name__}'
                 )
 
             self._items[item.id] = item
-
-    def __add__(self, other: 'ItemSet'):
-        """
-        Add two ItemSets together, creating a new ItemSet of the same type.
-        Both ItemSets must have the same type.
-
-        """
-        if type(other) is not self.__class__:
-            raise TypeError(
-                f'cannot add {self.__class__.__name__} '
-                f'and {type(other).__name__}'
-            )
-
-        # Copy all the items from this set to a new one
-        new_set = self.__class__([item for item in self])
-        new_set.add(other)
-        return new_set
 
     def remove(self, *items: Union[str, ItemBase]):
         """

--- a/runeq/resources/common.py
+++ b/runeq/resources/common.py
@@ -63,7 +63,10 @@ class ItemBase:
 
         """
         if hasattr(self, "name"):
-            return f'{self.__class__.__name__}(id="{self.id}", name="{self.name}")'
+            return (
+                f'{self.__class__.__name__}'
+                f'(id="{self.id}", name="{self.name}")'
+            )
         else:
             return f'{self.__class__.__name__}(id="{self.id}")'
 
@@ -174,7 +177,7 @@ class ItemSet(ABC):
         """
         return iter(self._items.keys())
 
-    def __str__(self):
+    def __repr__(self):
         """
         String representation of the set of items. Returns information on
         the number of items in the set, the type of the set, and up to 3

--- a/runeq/resources/common.py
+++ b/runeq/resources/common.py
@@ -61,13 +61,11 @@ class ItemBase:
         """
         Format the item representation.
 
-        TODO: should this be __str__ instead?
-
         """
         if hasattr(self, "name"):
-            return f'{self.__class__.__name__}(id={self.id}, name={self.name})'
+            return f'{self.__class__.__name__}(id="{self.id}", name="{self.name}")'
         else:
-            return f'{self.__class__.__name__}(id={self.id})'
+            return f'{self.__class__.__name__}(id="{self.id}")'
 
     def to_dict(self) -> dict:
         """
@@ -155,17 +153,6 @@ class ItemSet(ABC):
                 )
 
             self._items[item.id] = item
-
-    def __add__(self, other):
-        """
-        Add two ItemSets of the same type together. Items are deduplicated.
-
-        """
-        if type(other) != self.__class__:
-            raise TypeError(f'cannot add {self.__class__} and {type(other)}')
-
-        items = [i for i in other]
-        self.add(*items)
 
     def remove(self, *items: Union[str, ItemBase]):
         """

--- a/runeq/resources/common.py
+++ b/runeq/resources/common.py
@@ -61,11 +61,13 @@ class ItemBase:
         """
         Format the item representation.
 
+        TODO: should this be __str__ instead?
+
         """
-        return (
-            f'{self.__class__.__name__}(\n\tid={self._id},\n\t'
-            f'attributes={self._attributes}\n)'
-        )
+        if hasattr(self, "name"):
+            return f'{self.__class__.__name__}(id={self.id}, name={self.name})'
+        else:
+            return f'{self.__class__.__name__}(id={self.id})'
 
     def to_dict(self) -> dict:
         """
@@ -154,6 +156,17 @@ class ItemSet(ABC):
 
             self._items[item.id] = item
 
+    def __add__(self, other):
+        """
+        Add two ItemSets of the same type together. Items are deduplicated.
+
+        """
+        if type(other) != self.__class__:
+            raise TypeError(f'cannot add {self.__class__} and {type(other)}')
+
+        items = [i for i in other]
+        self.add(*items)
+
     def remove(self, *items: Union[str, ItemBase]):
         """
         Remove item(s) from this set.
@@ -178,14 +191,20 @@ class ItemSet(ABC):
         """
         String representation of the set of items. Returns information on
         the number of items in the set, the type of the set, and up to 3
-        item ids.
+        items.
 
         """
-        items_ids = self._items.keys()
-        items_str = ''.join([f'\t{str(id)}\n' for id in list(items_ids)[:3]])
-        if len(items_ids) > 3:
-            items_str += f'\t... (and {len(self._items.keys()) - 3} others)\n'
+        item_strs = []
+        for i, item in enumerate(self):
+            if i > 2:
+                item_strs.append(
+                    f'\t... (and {len(self._items.keys()) - 3} others)\n'
+                )
+                break
 
+            item_strs.append(f'\t{str(item)}\n')
+
+        items_str = ''.join(item_strs)
         return f'{type(self).__name__} {{\n{items_str}}}'
 
     def to_list(self) -> List[dict]:

--- a/runeq/resources/common.py
+++ b/runeq/resources/common.py
@@ -157,7 +157,8 @@ class ItemSet(ABC):
         for item in items:
             if type(item) is not self._item_class:
                 raise TypeError(
-                    f'cannot add {str(item)}; must be type {self._item_class.__name__}'
+                    f'cannot add {str(item)}; must be type '
+                    f'{self._item_class.__name__}'
                 )
 
             self._items[item.id] = item
@@ -170,7 +171,8 @@ class ItemSet(ABC):
         """
         if type(other) is not self.__class__:
             raise TypeError(
-                f'cannot add {self.__class__.__name__} and {type(other).__name__}'
+                f'cannot add {self.__class__.__name__} '
+                f'and {type(other).__name__}'
             )
 
         # Copy all the items from this set to a new one

--- a/runeq/resources/org.py
+++ b/runeq/resources/org.py
@@ -18,7 +18,7 @@ class Org(ItemBase):
     def __init__(
         self,
         id: str,
-        display_name: str,
+        name: str,
         created_at: float,
         **attributes
     ):
@@ -27,18 +27,18 @@ class Org(ItemBase):
 
         Args:
             id: ID of the organization
-            display_name: Human-readable name
+            name: Human-readable name
             created_at: When the organization was created (unix timestamp)
             **attributes: Other attributes associated with the organization
 
         """
         norm_id = Org.normalize_id(id)
-        self.display_name = display_name
+        self.name = name
         self.created_at = created_at
 
         super().__init__(
             id=norm_id,
-            display_name=display_name,
+            name=name,
             created_at=created_at,
             **attributes,
         )
@@ -119,7 +119,7 @@ def get_org(org_id: str, client: Optional[GraphClient] = None) -> Org:
             org (orgId: $org_id) {
                 id
                 created_at: created
-                display_name: displayName
+                name: displayName
             }
         }
     '''
@@ -135,7 +135,7 @@ def get_org(org_id: str, client: Optional[GraphClient] = None) -> Org:
     return Org(
         id=org_attrs["id"],
         created_at=org_attrs.get("created_at"),
-        display_name=org_attrs.get("display_name"),
+        name=org_attrs.get("name"),
     )
 
 
@@ -160,7 +160,7 @@ def get_orgs(client: Optional[GraphClient] = None) -> OrgSet:
                         org {
                             id
                             created_at: created
-                            display_name: displayName
+                            name: displayName
                         }
                     }
                 }
@@ -185,7 +185,7 @@ def get_orgs(client: Optional[GraphClient] = None) -> OrgSet:
             org = Org(
                 id=org_attrs["id"],
                 created_at=org_attrs.get("created_at"),
-                display_name=org_attrs.get("display_name"),
+                name=org_attrs.get("name"),
             )
             org_set.add(org)
 

--- a/runeq/resources/patient.py
+++ b/runeq/resources/patient.py
@@ -23,7 +23,7 @@ class Device(ItemBase):
         self,
         id: str,
         patient_id: str,
-        alias: str,
+        name: str,
         created_at: float,
         device_type_id: str,
         **attributes
@@ -34,20 +34,20 @@ class Device(ItemBase):
         Args:
             id: ID of the device
             patient_id: ID of the patient
-            alias: Human-readable name for the device
+            name: Human-readable name for the device
             created_at: When the device was created (unix timestamp)
             **attributes: Other attributes associated with the device
 
         """
         self.patient_id = patient_id
-        self.alias = alias
+        self.name = name
         self.created_at = created_at
         self.device_type_id = device_type_id
 
         super().__init__(
             id=id,
             patient_id=patient_id,
-            alias=alias,
+            name=name,
             created_at=created_at,
             device_type_id=device_type_id,
             **attributes,
@@ -86,6 +86,16 @@ class Device(ItemBase):
 
         return f'patient-{norm_patient_id},device-{norm_device_id}'
 
+    def __repr__(self):
+        """
+        Override repr, to include the patient ID
+
+        """
+        return (
+            f'{self.__class__.__name__}('
+            f'id={self.id}, name={self.name}, patient_id={self.patient_id})'
+        )
+
 
 class DeviceSet(ItemSet):
     """
@@ -122,7 +132,7 @@ class Patient(ItemBase):
     def __init__(
         self,
         id: str,
-        code_name: str,
+        name: str,
         created_at: float,
         devices: DeviceSet,
         **attributes
@@ -132,18 +142,18 @@ class Patient(ItemBase):
 
         Args:
             id: ID of the patient
-            code_name: Human-readable display name for the patient
+            name: Human-readable display name for the patient
             created_at: When the patient's record was created (unix timestamp)
             devices: Devices that belong to the patient
             **attributes: Other attributes associated with the patient
         """
-        self.code_name = code_name
+        self.name = name
         self.created_at = created_at
         self.devices = devices
 
         super().__init__(
             id=id,
-            code_name=code_name,
+            name=name,
             created_at=created_at,
             devices=devices,
             **attributes,
@@ -230,6 +240,7 @@ class PatientSet(ItemSet):
         """
         return Patient
 
+    @property
     def devices(self) -> DeviceSet:
         """
         Set of all devices that belong to the patients in this collection.
@@ -261,7 +272,7 @@ def get_patient(
         query getPatient($patient_id: ID!, $cursor: Cursor) {
             patient(id: $patient_id) {
                 id
-                code_name: codeName
+                name: codeName
                 created_at: createdAt
                 deviceList(cursor: $cursor) {
                     pageInfo {
@@ -269,8 +280,7 @@ def get_patient(
                     }
                     devices {
                         id: deviceShortId
-                        denormalized_id: id
-                        alias
+                        name: alias
                         created_at: createdAt
                         device_type: deviceType {
                             id
@@ -342,7 +352,7 @@ def get_all_patients(client: Optional[GraphClient] = None) -> PatientSet:
                     patientAccess {
                         patient {
                             id
-                            code_name: codeName
+                            name: codeName
                             created_at: createdAt
                             deviceList(cursor: $device_cursor) {
                                 pageInfo {
@@ -350,8 +360,7 @@ def get_all_patients(client: Optional[GraphClient] = None) -> PatientSet:
                                 }
                                 devices {
                                     id: deviceShortId
-                                    denormalized_id: id
-                                    alias
+                                    name: alias
                                     created_at: createdAt
                                     device_type: deviceType {
                                         id
@@ -453,7 +462,7 @@ def get_patient_devices(
     Get all devices for a patient.
 
     Note that if a Patient object is provided, this function serves
-    as a wrapper around Patient.devices(). If a patient ID is provided,
+    as a wrapper around Patient.devices. If a patient ID is provided,
     metadata is fetched from the API.
 
     Args:
@@ -496,4 +505,4 @@ def get_all_devices(
 
         return all_devices
 
-    return patients.devices()
+    return patients.devices

--- a/runeq/resources/patient.py
+++ b/runeq/resources/patient.py
@@ -93,7 +93,7 @@ class Device(ItemBase):
         """
         return (
             f'{self.__class__.__name__}('
-            f'id={self.id}, name={self.name}, patient_id={self.patient_id})'
+            f'id="{self.id}", name="{self.name}", patient_id="{self.patient_id}")'
         )
 
 

--- a/runeq/resources/patient.py
+++ b/runeq/resources/patient.py
@@ -88,12 +88,13 @@ class Device(ItemBase):
 
     def __repr__(self):
         """
-        Override repr, to include the patient ID
+        Override repr, to include the patient ID (as well as the device ID
+        and name)
 
         """
         return (
-            f'{self.__class__.__name__}('
-            f'id="{self.id}", name="{self.name}", patient_id="{self.patient_id}")'
+            f'{self.__class__.__name__}(id="{self.id}", '
+            f'name="{self.name}", patient_id="{self.patient_id}")'
         )
 
 

--- a/runeq/resources/stream_metadata.py
+++ b/runeq/resources/stream_metadata.py
@@ -820,8 +820,8 @@ def get_patient_stream_metadata(
     **parameters
 ) -> StreamMetadataSet:
     """
-    Get stream metadata for streams that match ALL filter parameters. Only the
-    patient ID is required.
+    Get stream metadata for a patient's streams, matching ALL filter
+    parameters. Only the patient ID is required.
 
     Args:
         patient_id: Patient ID
@@ -835,6 +835,7 @@ def get_patient_stream_metadata(
             (e.g. heart_rate, step_count, etc).
         client: If specified, this client is used to fetch metadata from the
             API. Otherwise, the global GraphClient is used.
+        **parameters: A
 
     """
     client = client or global_graph_client()

--- a/runeq/resources/user.py
+++ b/runeq/resources/user.py
@@ -18,10 +18,10 @@ class User(ItemBase):
     def __init__(
         self,
         id: str,
-        display_name: str,
+        name: str,
         created_at: float,
         active_org_id: str,
-        active_org_display_name: str,
+        active_org_name: str,
         **attributes
     ):
         """
@@ -29,25 +29,25 @@ class User(ItemBase):
 
         Args:
             id: User ID
-            display_name: Human-readable display name for the user
+            name: Human-readable display name for the user
             created_at: When the user was created (unix timestamp)
             active_org_id: ID of the user's currently active organization
-            active_org_display_name: Display name of the user's currently
+            active_org_name: Display name of the user's currently
                 active organization
 
         """
         norm_id = id
-        self.display_name = display_name
+        self.name = name
         self.created_at = created_at
         self.active_org_id = active_org_id
-        self.active_org_display_name = active_org_display_name
+        self.active_org_name = active_org_name
 
         super().__init__(
             id=norm_id,
-            display_name=display_name,
+            name=name,
             created_at=created_at,
             active_org_id=active_org_id,
-            active_org_display_name=active_org_display_name,
+            active_org_name=active_org_name,
             **attributes,
         )
 
@@ -83,11 +83,11 @@ def get_current_user(client: Optional[GraphClient] = None) -> User:
             user {
                 id
                 created_at: created
-                display_name: displayName
+                name: displayName
                 defaultMembership {
                     org {
                         id
-                        display_name: displayName
+                        name: displayName
                     }
                 }
                 email
@@ -103,9 +103,9 @@ def get_current_user(client: Optional[GraphClient] = None) -> User:
 
     return User(
         id=user_attrs["id"],
-        display_name=user_attrs.get("display_name"),
+        name=user_attrs.get("name"),
         created_at=user_attrs.get("created_at"),
         active_org_id=org.get("id"),
-        active_org_display_name=org.get("display_name"),
+        active_org_name=org.get("name"),
         email=user_attrs.get("email")
     )

--- a/tests/resources/test_common.py
+++ b/tests/resources/test_common.py
@@ -287,15 +287,15 @@ class TestItemSet(TestCase):
             list(self.test_patient_set.ids())
         )
 
-    def test_str(self):
+    def test_repr(self):
         """
-        Test __str__
+        Test __repr__
 
         """
         self.assertEqual(
             """PatientItemSet {
 }""",
-            str(PatientItemSet())
+            repr(PatientItemSet())
         )
 
         patient_set = PatientItemSet(

--- a/tests/resources/test_common.py
+++ b/tests/resources/test_common.py
@@ -1,11 +1,11 @@
 """
-Tests for the V2 SDK Common Classes.
+Tests for common base classes.
 
 """
 from typing import List, Type
 from unittest import TestCase
 
-from runeq.v2sdk.common import ItemBase, ItemSet
+from runeq.resources.common import ItemBase, ItemSet
 
 
 class StreamItem(ItemBase):
@@ -124,13 +124,13 @@ class TestItemBase(TestCase):
         """
         patient1 = PatientItem(id="patient_id1")
         self.assertEqual(
-            'PatientItem(id=patient_id1)',
+            'PatientItem(id="patient_id1")',
             repr(patient1)
         )
 
         patient2 = PatientItem(id="patient_id2", key1="val1")
         self.assertEqual(
-            "PatientItem(id=patient_id2)",
+            'PatientItem(id="patient_id2")',
             repr(patient2)
         )
 
@@ -315,9 +315,9 @@ class TestItemSet(TestCase):
         self.assertEqual(
             (
                 'PatientItemSet {\n'
-                '	PatientItem(id=patient1_id)\n'
-                '	PatientItem(id=patient2_id)\n'
-                '	PatientItem(id=patient3_id)\n'
+                '	PatientItem(id="patient1_id")\n'
+                '	PatientItem(id="patient2_id")\n'
+                '	PatientItem(id="patient3_id")\n'
                 '	... (and 2 others)\n'
                 '}'
             ),

--- a/tests/resources/test_common.py
+++ b/tests/resources/test_common.py
@@ -6,6 +6,7 @@ from typing import List, Type
 from unittest import TestCase
 
 from runeq.resources.common import ItemBase, ItemSet
+from runeq.resources.org import OrgSet
 
 
 class StreamItem(ItemBase):
@@ -210,33 +211,74 @@ class TestItemSet(TestCase):
         Test add
 
         """
+        patient1 = PatientItem(id="patient1_id")
+        patient2 = PatientItem(id="patient2_id")
+
         # Test successfully adding a new patient to a set
         patient_set = PatientItemSet()
         self.assertEqual(0, len(patient_set))
 
-        new_patient = PatientItem(id="patient1_id")
-        patient_set.add(new_patient)
+        patient_set.add(patient1)
         self.assertEqual(1, len(patient_set))
-        self.assertEqual(new_patient, patient_set.get("patient1_id"))
+        self.assertEqual(patient1, patient_set.get("patient1_id"))
 
         # Test adding multiple patients to a set
         patient_set = PatientItemSet()
-        patient2 = PatientItem(id="patient2_id")
-        patient_set.add(new_patient, new_patient, patient2)
+        patient_set.add([patient1, patient1, patient2])
         self.assertEqual(2, len(patient_set))
-        self.assertEqual(new_patient, patient_set.get("patient1_id"))
+        self.assertEqual(patient1, patient_set.get("patient1_id"))
+        self.assertEqual(patient2, patient_set.get("patient2_id"))
+
+        # Test adding two ItemSets
+        patient_set = PatientItemSet([patient1])
+        patient_set.add(PatientItemSet([patient2]))
+
+        self.assertEqual(2, len(patient_set))
+        self.assertEqual(patient1, patient_set.get("patient1_id"))
         self.assertEqual(patient2, patient_set.get("patient2_id"))
 
         # Test raises TypeError when adding item with a different
         # type to the set.
         patient_set = PatientItemSet()
-        new_stream = StreamItem(id="strean1_id")
+        new_stream = StreamItem(id="stream1_id")
 
         with self.assertRaisesRegex(
             TypeError,
-            "cannot add"
+            f"must be type PatientItem"
         ):
-            patient_set.add(new_stream)
+            patient_set.add([new_stream])
+
+    def test__add__(self):
+        """
+        Test __add__
+
+        """
+        patient1 = PatientItem(id="patient1_id")
+        patient2 = PatientItem(id="patient2_id")
+
+        # Adding two ItemSets together should create a third
+        patient_set1 = PatientItemSet([patient1])
+        patient_set2 = PatientItemSet([patient2])
+
+        patient_set3 = patient_set1 + patient_set2
+
+        self.assertEqual(len(patient_set3), 2)
+        self.assertEqual(
+            set(patient_set3.ids()), {"patient1_id", "patient2_id"})
+
+        # Original ItemSets should be unaffected
+        self.assertEqual(len(patient_set1), 1)
+        self.assertEqual(set(patient_set1.ids()), {"patient1_id"})
+
+        self.assertEqual(len(patient_set2), 1)
+        self.assertEqual(set(patient_set2.ids()), {"patient2_id"})
+
+        # Test raises TypeError when adding ItemSets with different types
+        with self.assertRaisesRegex(
+            TypeError,
+            "cannot add PatientItemSet and OrgSet"
+        ):
+            PatientItemSet() + OrgSet()
 
     def test_remove(self):
         """

--- a/tests/resources/test_common.py
+++ b/tests/resources/test_common.py
@@ -154,6 +154,10 @@ class TestItemSet(TestCase):
     """
 
     def setUp(self) -> None:
+        """
+        Test setup
+
+        """
         self.test_patient_set = PatientItemSet(
             items=[
                 PatientItem(id="patient1_id", name="Patient 1"),
@@ -208,70 +212,55 @@ class TestItemSet(TestCase):
         patient2 = PatientItem(id="patient2_id")
 
         # Test successfully adding a new patient to a set
-        patient_set = PatientItemSet()
-        self.assertEqual(0, len(patient_set))
-
-        patient_set.add(patient1)
-        self.assertEqual(1, len(patient_set))
-        self.assertEqual(patient1, patient_set.get("patient1_id"))
-
-        # Test adding multiple patients to a set
-        patient_set = PatientItemSet()
-        patient_set.add([patient1, patient1, patient2])
-        self.assertEqual(2, len(patient_set))
-        self.assertEqual(patient1, patient_set.get("patient1_id"))
-        self.assertEqual(patient2, patient_set.get("patient2_id"))
-
-        # Test adding two ItemSets
         patient_set = PatientItemSet([patient1])
-        patient_set.add(PatientItemSet([patient2]))
+        self.assertEqual(1, len(patient_set))
 
+        patient_set.add(patient2)
         self.assertEqual(2, len(patient_set))
-        self.assertEqual(patient1, patient_set.get("patient1_id"))
-        self.assertEqual(patient2, patient_set.get("patient2_id"))
+        self.assertEqual({"patient1_id", "patient2_id"},
+                         set(patient_set.ids()))
 
         # Test raises TypeError when adding item with a different
         # type to the set.
         patient_set = PatientItemSet()
         new_stream = StreamItem(id="stream1_id")
 
-        with self.assertRaisesRegex(
-            TypeError,
-            f"must be type PatientItem"
-        ):
-            patient_set.add([new_stream])
+        with self.assertRaisesRegex(TypeError, "must be type PatientItem"):
+            patient_set.add(new_stream)
 
-    def test__add__(self):
+    def test_update(self):
         """
-        Test __add__
+        Test update
 
         """
         patient1 = PatientItem(id="patient1_id")
         patient2 = PatientItem(id="patient2_id")
 
-        # Adding two ItemSets together should create a third
+        # Test update with a list
+        patient_set = PatientItemSet()
+        patient_set.update([patient1, patient1, patient2])
+        self.assertEqual(2, len(patient_set))
+        self.assertEqual(patient1, patient_set.get("patient1_id"))
+        self.assertEqual(patient2, patient_set.get("patient2_id"))
+
+        # Test update with a ItemSet of the same type
         patient_set1 = PatientItemSet([patient1])
         patient_set2 = PatientItemSet([patient2])
+        patient_set1.update(patient_set2)
 
-        patient_set3 = patient_set1 + patient_set2
+        self.assertEqual(2, len(patient_set1))
+        self.assertEqual(patient1, patient_set.get("patient1_id"))
+        self.assertEqual(patient2, patient_set.get("patient2_id"))
 
-        self.assertEqual(len(patient_set3), 2)
-        self.assertEqual(
-            set(patient_set3.ids()), {"patient1_id", "patient2_id"})
-
-        # Original ItemSets should be unaffected
-        self.assertEqual(len(patient_set1), 1)
-        self.assertEqual(set(patient_set1.ids()), {"patient1_id"})
-
-        self.assertEqual(len(patient_set2), 1)
-        self.assertEqual(set(patient_set2.ids()), {"patient2_id"})
+        # other patient set is unaffected
+        self.assertEqual(1, len(patient_set2))
 
         # Test raises TypeError when adding ItemSets with different types
         with self.assertRaisesRegex(
             TypeError,
-            "cannot add PatientItemSet and OrgSet"
+            "cannot update with PatientItem"
         ):
-            PatientItemSet() + OrgSet()
+            OrgSet().update(patient_set)
 
     def test_remove(self):
         """

--- a/tests/resources/test_common.py
+++ b/tests/resources/test_common.py
@@ -22,14 +22,6 @@ class StreamItem(ItemBase):
         """
         super().__init__(id=id, **attributes)
 
-    @property
-    def id(self) -> str:
-        """
-        ID of the Stream
-
-        """
-        return self._attributes.get("id")
-
 
 class PatientItem(ItemBase):
     """
@@ -37,20 +29,13 @@ class PatientItem(ItemBase):
 
     """
 
-    def __init__(self, id: str, **attributes):
+    def __init__(self, id: str, name: str = "", **attributes):
         """
         Initializes PatientItem
 
         """
-        super().__init__(id=id, **attributes)
-
-    @property
-    def id(self) -> str:
-        """
-        ID of the Patient
-
-        """
-        return self._attributes.get("id")
+        self.name = name
+        super().__init__(id=id, name=name, **attributes)
 
 
 class PatientItemSet(ItemSet):
@@ -123,16 +108,18 @@ class TestItemBase(TestCase):
         Test __repr__
 
         """
-        patient1 = PatientItem(id="patient_id1")
+        # Class that has a name attribute
+        patient = PatientItem(id="patient_id1", name="Patient 1", key1="val1")
         self.assertEqual(
-            'PatientItem(id="patient_id1")',
-            repr(patient1)
+            'PatientItem(id="patient_id1", name="Patient 1")',
+            repr(patient)
         )
 
-        patient2 = PatientItem(id="patient_id2", key1="val1")
+        # Class that doesn't have a name attribute
+        stream = StreamItem(id="stream-123", )
         self.assertEqual(
-            'PatientItem(id="patient_id2")',
-            repr(patient2)
+            'StreamItem(id="stream-123")',
+            repr(stream)
         )
 
     def test_to_dict(self):
@@ -141,15 +128,21 @@ class TestItemBase(TestCase):
 
         """
         patient1 = PatientItem(id="patient_id")
-        self.assertEqual({"id": "patient_id"}, patient1.to_dict())
+        self.assertEqual({"id": "patient_id", "name": ""}, patient1.to_dict())
 
         patient2 = PatientItem(
             id="patient_id",
+            name='Patient 2',
             key1="val1",
             key2=2
         )
         self.assertEqual(
-            {"id": "patient_id", "key1": "val1", "key2": 2},
+            {
+                "id": "patient_id",
+                "name": "Patient 2",
+                "key1": "val1",
+                "key2": 2
+            },
             patient2.to_dict()
         )
 
@@ -160,13 +153,14 @@ class TestItemSet(TestCase):
 
     """
 
-    test_patient_set = PatientItemSet(
-        items=[
-            PatientItem(id="patient1_id"),
-            PatientItem(id="patient2_id", key1="val1"),
-            PatientItem(id="patient3_id", key1=1, key2="val2"),
-        ]
-    )
+    def setUp(self) -> None:
+        self.test_patient_set = PatientItemSet(
+            items=[
+                PatientItem(id="patient1_id", name="Patient 1"),
+                PatientItem(id="patient2_id", key1="val1"),
+                PatientItem(id="patient3_id", key1=1, key2="val2"),
+            ]
+        )
 
     def test_iter(self):
         """
@@ -187,7 +181,6 @@ class TestItemSet(TestCase):
         """
         self.assertEqual(0, len(PatientItemSet()))
         self.assertEqual(3, len(self.test_patient_set))
-
 
     def test_get(self):
         """
@@ -342,13 +335,9 @@ class TestItemSet(TestCase):
 
         patient_set = PatientItemSet(
             items=[
-                PatientItem(id="patient1_id"),
-                PatientItem(id="patient2_id", key1="val1"),
-                PatientItem(
-                    id="patient3_id",
-                    key1=1,
-                    key2="val2"
-                ),
+                PatientItem(id="patient1_id", name=""),
+                PatientItem(id="patient2_id", name="Patient 2"),
+                PatientItem(id="patient3_id", name="Patient 3", key1="value1"),
                 PatientItem(id="patient4_id"),
                 PatientItem(id="patient5_id"),
             ]
@@ -357,9 +346,9 @@ class TestItemSet(TestCase):
         self.assertEqual(
             (
                 'PatientItemSet {\n'
-                '	PatientItem(id="patient1_id")\n'
-                '	PatientItem(id="patient2_id")\n'
-                '	PatientItem(id="patient3_id")\n'
+                '	PatientItem(id="patient1_id", name="")\n'
+                '	PatientItem(id="patient2_id", name="Patient 2")\n'
+                '	PatientItem(id="patient3_id", name="Patient 3")\n'
                 '	... (and 2 others)\n'
                 '}'
             ),
@@ -375,9 +364,9 @@ class TestItemSet(TestCase):
         self.assertEqual([], PatientItemSet().to_list())
         self.assertEqual(
             [
-                {'id': 'patient1_id'},
-                {'id': 'patient2_id', 'key1': 'val1'},
-                {'id': 'patient3_id', 'key1': 1, 'key2': 'val2'},
+                {'id': 'patient1_id', 'name': 'Patient 1'},
+                {'id': 'patient2_id', 'key1': 'val1', 'name': ''},
+                {'id': 'patient3_id', 'key1': 1, 'key2': 'val2', 'name': ''},
             ],
             self.test_patient_set.to_list()
         )

--- a/tests/resources/test_common.py
+++ b/tests/resources/test_common.py
@@ -5,7 +5,7 @@ Tests for the V2 SDK Common Classes.
 from typing import List, Type
 from unittest import TestCase
 
-from runeq.resources.common import ItemBase, ItemSet
+from runeq.v2sdk.common import ItemBase, ItemSet
 
 
 class StreamItem(ItemBase):
@@ -122,20 +122,15 @@ class TestItemBase(TestCase):
         Test __repr__
 
         """
-        patient1 = PatientItem(id="patient_id")
+        patient1 = PatientItem(id="patient_id1")
         self.assertEqual(
-            'PatientItem(\n\tid=patient_id,\n\tattributes='
-            '{\'id\': \'patient_id\'}\n)',
+            'PatientItem(id=patient_id1)',
             repr(patient1)
         )
 
-
-        patient2 = PatientItem(id="patient_id", key1="val1")
+        patient2 = PatientItem(id="patient_id2", key1="val1")
         self.assertEqual(
-            (
-                "PatientItem(\n\tid=patient_id,\n\t"
-                "attributes={'key1': 'val1', 'id': 'patient_id'}\n)"
-            ),
+            "PatientItem(id=patient_id2)",
             repr(patient2)
         )
 
@@ -320,9 +315,9 @@ class TestItemSet(TestCase):
         self.assertEqual(
             (
                 'PatientItemSet {\n'
-                '	patient1_id\n'
-                '	patient2_id\n'
-                '	patient3_id\n'
+                '	PatientItem(id=patient1_id)\n'
+                '	PatientItem(id=patient2_id)\n'
+                '	PatientItem(id=patient3_id)\n'
                 '	... (and 2 others)\n'
                 '}'
             ),

--- a/tests/resources/test_org.py
+++ b/tests/resources/test_org.py
@@ -1,12 +1,12 @@
 """
-Tests for the V2 SDK Org.
+Tests for fetching org metadata.
 
 """
 from unittest import TestCase, mock
 
 from runeq.config import Config
-from runeq.v2sdk.client import GraphClient
-from runeq.v2sdk.org import Org, get_org, get_orgs
+from runeq.resources.client import GraphClient
+from runeq.resources.org import Org, get_org, get_orgs
 
 
 class TestOrg(TestCase):
@@ -50,10 +50,10 @@ class TestOrg(TestCase):
         test_org = Org(
             id="org1-id",
             created_at=1629300943.9179766,
-            name="org1",
+            name="Org 1",
         )
         self.assertEqual(
-            "Org(id=org1-id, name=org1)",
+            'Org(id="org1-id", name="Org 1")',
             repr(test_org)
         )
 

--- a/tests/resources/test_org.py
+++ b/tests/resources/test_org.py
@@ -5,8 +5,8 @@ Tests for the V2 SDK Org.
 from unittest import TestCase, mock
 
 from runeq.config import Config
-from runeq.resources.client import GraphClient
-from runeq.resources.org import Org, get_org, get_orgs
+from runeq.v2sdk.client import GraphClient
+from runeq.v2sdk.org import Org, get_org, get_orgs
 
 
 class TestOrg(TestCase):
@@ -35,12 +35,27 @@ class TestOrg(TestCase):
         test_org = Org(
             id="org1-id",
             created_at=1629300943.9179766,
-            display_name="org1",
+            name="org1",
         )
 
         self.assertEqual("org1-id", test_org.id)
         self.assertEqual(1629300943.9179766, test_org.created_at)
-        self.assertEqual("org1", test_org.display_name)
+        self.assertEqual("org1", test_org.name)
+
+    def test_repr(self):
+        """
+        Test __repr__
+
+        """
+        test_org = Org(
+            id="org1-id",
+            created_at=1629300943.9179766,
+            name="org1",
+        )
+        self.assertEqual(
+            "Org(id=org1-id, name=org1)",
+            repr(test_org)
+        )
 
     def test_normalize_id(self):
         """
@@ -103,7 +118,7 @@ class TestOrg(TestCase):
                 "org": {
                     "id": "org1-id",
                     "created_at": 1630515986.9949625,
-                    "display_name": "org1"
+                    "name": "org1"
                 }
             }
         ]
@@ -114,7 +129,7 @@ class TestOrg(TestCase):
             {
                 "id": "org1-id",
                 "created_at": 1630515986.9949625,
-                "display_name": "org1"
+                "name": "org1"
             },
             org.to_dict(),
         )
@@ -137,21 +152,21 @@ class TestOrg(TestCase):
                                 "org": {
                                     "id": "org1-id",
                                     "created_at": 1571267538.391721,
-                                    "display_name": "org1"
+                                    "name": "org1"
                                 }
                             },
                             {
                                 "org": {
                                     "id": "org2-id",
                                     "created_at": 1630515986.9949625,
-                                    "display_name": "org2"
+                                    "name": "org2"
                                 }
                             },
                             {
                                 "org": {
                                     "id": "org3-id",
                                     "created_at": 1649888079.066764,
-                                    "display_name": "org3"
+                                    "name": "org3"
                                 }
                             }
                         ]
@@ -166,17 +181,17 @@ class TestOrg(TestCase):
             [
                 {
                     'created_at': 1571267538.391721,
-                    'display_name': 'org1',
+                    'name': 'org1',
                     'id': 'org1-id'
                 },
                 {
                     'created_at': 1630515986.9949625,
-                    'display_name': 'org2',
+                    'name': 'org2',
                     'id': 'org2-id'
                 },
                 {
                     'created_at': 1649888079.066764,
-                    'display_name': 'org3',
+                    'name': 'org3',
                     'id': 'org3-id'
                 }
             ],
@@ -202,7 +217,7 @@ class TestOrg(TestCase):
                                 "org": {
                                     "id": "org1-id",
                                     "created_at": 1571267538.391721,
-                                    "display_name": "org1"
+                                    "name": "org1"
                                 }
                             }
                         ]
@@ -220,7 +235,7 @@ class TestOrg(TestCase):
                                 "org": {
                                     "id": "org2-id",
                                     "created_at": 1630515986.9949625,
-                                    "display_name": "org2"
+                                    "name": "org2"
                                 }
                             }
                         ]
@@ -235,12 +250,12 @@ class TestOrg(TestCase):
             [
                 {
                     'created_at': 1571267538.391721,
-                    'display_name': 'org1',
+                    'name': 'org1',
                     'id': 'org1-id'
                 },
                 {
                     'created_at': 1630515986.9949625,
-                    'display_name': 'org2',
+                    'name': 'org2',
                     'id': 'org2-id'
                 }
             ],

--- a/tests/resources/test_patient.py
+++ b/tests/resources/test_patient.py
@@ -5,8 +5,8 @@ Tests for the V2 SDK Patient.
 from unittest import TestCase, mock
 
 from runeq.config import Config
-from runeq.resources.client import GraphClient
-from runeq.resources.patient import (
+from runeq.v2sdk.client import GraphClient
+from runeq.v2sdk.patient import (
     Device, DeviceSet, Patient, PatientSet, get_all_devices, get_all_patients,
     get_device, get_patient, get_patient_devices
 )
@@ -38,20 +38,20 @@ class TestPatient(TestCase):
         test_patient = Patient(
             id="p1",
             created_at=1629300943.9179766,
-            code_name="patient1",
+            name="patient1",
             devices=DeviceSet(
                 [
                     Device(
                         id="d1",
                         patient_id="p1",
-                        alias="Percept",
+                        name="Percept",
                         created_at=1629300943.9179766,
                         device_type_id="dt1",
                     ),
                     Device(
                         id="d2",
                         patient_id="p1",
-                        alias="Apple Watch",
+                        name="Apple Watch",
                         created_at=1629300943.9179766,
                         device_type_id="dt2",
                     )
@@ -61,7 +61,7 @@ class TestPatient(TestCase):
 
         self.assertEqual("p1", test_patient.id)
         self.assertEqual(1629300943.9179766, test_patient.created_at)
-        self.assertEqual("patient1", test_patient.code_name)
+        self.assertEqual("patient1", test_patient.name)
 
         actual_devices = test_patient.devices.to_list()
         self.assertEqual(2, len(actual_devices))
@@ -70,7 +70,7 @@ class TestPatient(TestCase):
             {
                 "id": "d1",
                 "patient_id": "p1",
-                "alias": "Percept",
+                "name": "Percept",
                 "created_at": 1629300943.9179766,
                 "device_type_id": "dt1",
             },
@@ -81,7 +81,7 @@ class TestPatient(TestCase):
             {
                 "id": "d2",
                 "patient_id": "p1",
-                "alias": "Apple Watch",
+                "name": "Apple Watch",
                 "created_at": 1629300943.9179766,
                 "device_type_id": "dt2",
             },
@@ -92,11 +92,27 @@ class TestPatient(TestCase):
             Device(
                 id="d1",
                 patient_id="p1",
-                alias="Percept",
+                name="Percept",
                 created_at=1629300943.9179766,
                 device_type_id="dt1",
             ),
             test_patient.device("d1")
+        )
+
+    def test_repr(self):
+        """
+        Test __repr__
+
+        """
+        test_patient = Patient(
+            id="p1",
+            created_at=1629300943.9179766,
+            name="patient1",
+            devices=DeviceSet()
+        )
+        self.assertEqual(
+            "Patient(id=p1, name=patient1)",
+            repr(test_patient)
         )
 
     def test_normalize_id(self):
@@ -140,7 +156,7 @@ class TestPatient(TestCase):
                 "patient": {
                     "id": "p1",
                     "created_at": 1630515986.9949625,
-                    "code_name": "patient1",
+                    "name": "patient1",
                     "deviceList": {
                         "pageInfo": {
                             "endCursor": None
@@ -148,8 +164,7 @@ class TestPatient(TestCase):
                         "devices": [
                             {
                                 "id": "d1",
-                                "denormalized_id": "patient-p1,device-d1",
-                                "alias": "Percept",
+                                "name": "Percept",
                                 "created_at": 1646685476.1367705,
                                 "device_type": {
                                     "id": "dt1",
@@ -161,8 +176,7 @@ class TestPatient(TestCase):
                             },
                             {
                                 "id": "d2",
-                                "denormalized_id": "patient-p1,device-d2",
-                                "alias": "Strive PD",
+                                "name": "Strive PD",
                                 "created_at": 1646684177.194158,
                                 "device_type": {
                                     "id": "dt2",
@@ -174,8 +188,7 @@ class TestPatient(TestCase):
                             },
                             {
                                 "id": "d3",
-                                "denormalized_id": "patient-p1,device-d3",
-                                "alias": "Apple Watch",
+                                "name": "Apple Watch",
                                 "created_at": 1646684177.1942198,
                                 "device_type": {
                                     "id": "dt3",
@@ -197,12 +210,11 @@ class TestPatient(TestCase):
             {
                 "id": "p1",
                 "created_at": 1630515986.9949625,
-                "code_name": "patient1",
+                "name": "patient1",
                 "devices": [
                     {
-                        "denormalized_id": "patient-p1,device-d1",
                         "patient_id": "p1",
-                        "alias": "Percept",
+                        "name": "Percept",
                         "created_at": 1646685476.1367705,
                         "device_type_id": "dt1",
                         "disabled": False,
@@ -211,9 +223,8 @@ class TestPatient(TestCase):
                         "id": "d1"
                     },
                     {
-                        "denormalized_id": "patient-p1,device-d2",
                         "patient_id": "p1",
-                        "alias": "Strive PD",
+                        "name": "Strive PD",
                         "created_at": 1646684177.194158,
                         "device_type_id": "dt2",
                         "disabled": False,
@@ -222,9 +233,8 @@ class TestPatient(TestCase):
                         "id": "d2"
                     },
                     {
-                        "denormalized_id": "patient-p1,device-d3",
                         "patient_id": "p1",
-                        "alias": "Apple Watch",
+                        "name": "Apple Watch",
                         "created_at": 1646684177.1942198,
                         "device_type_id": "dt3",
                         "disabled": True,
@@ -250,7 +260,7 @@ class TestPatient(TestCase):
                 "patient": {
                     "id": "p1",
                     "created_at": 1630515986.9949625,
-                    "code_name": "patient1",
+                    "name": "patient1",
                     "deviceList": {
                         "pageInfo": {
                             "endCursor": "test_check_next"
@@ -258,8 +268,7 @@ class TestPatient(TestCase):
                         "devices": [
                             {
                                 "id": "d1",
-                                "denormalized_id": "patient-p1,device-d1",
-                                "alias": "Percept",
+                                "name": "Percept",
                                 "created_at": 1646685476.1367705,
                                 "device_type": {
                                     "id": "dt1",
@@ -276,7 +285,7 @@ class TestPatient(TestCase):
                 "patient": {
                     "id": "p1",
                     "created_at": 1630515986.9949625,
-                    "code_name": "patient1",
+                    "name": "patient1",
                     "deviceList": {
                         "pageInfo": {
                             "endCursor": None
@@ -284,8 +293,7 @@ class TestPatient(TestCase):
                         "devices": [
                             {
                                 "id": "d2",
-                                "denormalized_id": "patient-p1,device-d2",
-                                "alias": "Strive PD",
+                                "name": "Strive PD",
                                 "created_at": 1646684177.194158,
                                 "device_type": {
                                     "id": "dt2",
@@ -306,12 +314,11 @@ class TestPatient(TestCase):
             {
                 "id": "p1",
                 "created_at": 1630515986.9949625,
-                "code_name": "patient1",
+                "name": "patient1",
                 "devices": [
                     {
-                        "denormalized_id": "patient-p1,device-d1",
                         "patient_id": "p1",
-                        "alias": "Percept",
+                        "name": "Percept",
                         "created_at": 1646685476.1367705,
                         "device_type_id": "dt1",
                         "disabled": False,
@@ -320,9 +327,8 @@ class TestPatient(TestCase):
                         "id": "d1"
                     },
                     {
-                        "denormalized_id": "patient-p1,device-d2",
                         "patient_id": "p1",
-                        "alias": "Strive PD",
+                        "name": "Strive PD",
                         "created_at": 1646684177.194158,
                         "device_type_id": "dt2",
                         "disabled": False,
@@ -344,7 +350,7 @@ class TestPatient(TestCase):
             "patient": {
                 "id": "p1",
                 "created_at": 1630515986.9949625,
-                "code_name": "patient1",
+                "name": "patient1",
                 "deviceList": {
                     "pageInfo": {
                         "endCursor": None
@@ -352,8 +358,7 @@ class TestPatient(TestCase):
                     "devices": [
                         {
                             "id": "d1",
-                            "denormalized_id": "patient-p1,device-d1",
-                            "alias": "Percept",
+                            "name": "Percept",
                             "created_at": 1646685476.1367705,
                             "device_type": {
                                 "id": "dt1",
@@ -371,7 +376,7 @@ class TestPatient(TestCase):
             "patient": {
                 "id": "p2",
                 "created_at": 1630515986.9949625,
-                "code_name": "patient2",
+                "name": "patient2",
                 "deviceList": {
                     "pageInfo": {
                         "endCursor": None
@@ -379,8 +384,7 @@ class TestPatient(TestCase):
                     "devices": [
                         {
                             "id": "d1",
-                            "denormalized_id": "patient-p2,device-d1",
-                            "alias": "Percept",
+                            "name": "Percept",
                             "created_at": 1646685476.1367705,
                             "device_type": {
                                 "id": "dt1",
@@ -419,12 +423,11 @@ class TestPatient(TestCase):
                 {
                     "id": "p1",
                     "created_at": 1630515986.9949625,
-                    "code_name": "patient1",
+                    "name": "patient1",
                     "devices": [
                         {
-                            "denormalized_id": "patient-p1,device-d1",
                             "patient_id": "p1",
-                            "alias": "Percept",
+                            "name": "Percept",
                             "created_at": 1646685476.1367705,
                             "device_type_id": "dt1",
                             "disabled": False,
@@ -437,12 +440,11 @@ class TestPatient(TestCase):
                 {
                     "id": "p2",
                     "created_at": 1630515986.9949625,
-                    "code_name": "patient2",
+                    "name": "patient2",
                     "devices": [
                         {
-                            "denormalized_id": "patient-p2,device-d1",
                             "patient_id": "p2",
-                            "alias": "Percept",
+                            "name": "Percept",
                             "created_at": 1646685476.1367705,
                             "device_type_id": "dt1",
                             "disabled": False,
@@ -467,7 +469,7 @@ class TestPatient(TestCase):
             "patient": {
                 "id": "p1",
                 "created_at": 1630515986.9949625,
-                "code_name": "patient1",
+                "name": "patient1",
                 "deviceList": {
                     "pageInfo": {
                         "endCursor": None
@@ -475,8 +477,7 @@ class TestPatient(TestCase):
                     "devices": [
                         {
                             "id": "d1",
-                            "denormalized_id": "patient-p1,device-d1",
-                            "alias": "Percept",
+                            "name": "Percept",
                             "created_at": 1646685476.1367705,
                             "device_type": {
                                 "id": "dt1",
@@ -494,7 +495,7 @@ class TestPatient(TestCase):
             "patient": {
                 "id": "p2",
                 "created_at": 1630515986.9949625,
-                "code_name": "patient2",
+                "name": "patient2",
                 "deviceList": {
                     "pageInfo": {
                         "endCursor": None
@@ -502,8 +503,7 @@ class TestPatient(TestCase):
                     "devices": [
                         {
                             "id": "d1",
-                            "denormalized_id": "patient-p2,device-d1",
-                            "alias": "Percept",
+                            "name": "Percept",
                             "created_at": 1646685476.1367705,
                             "device_type": {
                                 "id": "dt1",
@@ -553,12 +553,11 @@ class TestPatient(TestCase):
                 {
                     "id": "p1",
                     "created_at": 1630515986.9949625,
-                    "code_name": "patient1",
+                    "name": "patient1",
                     "devices": [
                         {
-                            "denormalized_id": "patient-p1,device-d1",
                             "patient_id": "p1",
-                            "alias": "Percept",
+                            "name": "Percept",
                             "created_at": 1646685476.1367705,
                             "device_type_id": "dt1",
                             "disabled": False,
@@ -571,12 +570,11 @@ class TestPatient(TestCase):
                 {
                     "id": "p2",
                     "created_at": 1630515986.9949625,
-                    "code_name": "patient2",
+                    "name": "patient2",
                     "devices": [
                         {
-                            "denormalized_id": "patient-p2,device-d1",
                             "patient_id": "p2",
-                            "alias": "Percept",
+                            "name": "Percept",
                             "created_at": 1646685476.1367705,
                             "device_type_id": "dt1",
                             "disabled": False,
@@ -618,17 +616,33 @@ class TestDevice(TestCase):
         test_device = Device(
             id="device-1",
             patient_id="patient-1",
-            alias="Percept",
+            name="Percept",
             created_at=1629300943.9179766,
             device_type_id="dt1",
         )
 
         self.assertEqual("device-1", test_device.id)
         self.assertEqual("patient-1", test_device.patient_id)
-        self.assertEqual("Percept", test_device.alias)
+        self.assertEqual("Percept", test_device.name)
         self.assertEqual(1629300943.9179766, test_device.created_at)
         self.assertEqual("dt1", test_device.device_type_id)
 
+    def test_repr(self):
+        """
+        Test __repr__
+
+        """
+        test_device = Device(
+            id="1",
+            patient_id="p1",
+            name="Percept",
+            created_at=1629300943.9179766,
+            device_type_id="dt1",
+        )
+        self.assertEqual(
+            "Device(id=1, name=Percept, patient_id=p1)",
+            repr(test_device)
+        )
 
     def test_normalize_id(self):
         """
@@ -691,7 +705,7 @@ class TestDevice(TestCase):
         test_device = Device(
             id="1",
             patient_id="p1",
-            alias="Percept",
+            name="Percept",
             created_at=1629300943.9179766,
             device_type_id="dt1",
         )
@@ -699,7 +713,7 @@ class TestDevice(TestCase):
         test_patient = Patient(
             id="p1",
             created_at=1629300943.9179766,
-            code_name="patient1",
+            name="patient1",
             devices=DeviceSet(
                 [
                     test_device
@@ -721,7 +735,7 @@ class TestDevice(TestCase):
         test_device_1 = Device(
             id="d1",
             patient_id="p1",
-            alias="Percept",
+            name="Percept",
             created_at=1629300943.9179766,
             device_type_id="dt1",
         )
@@ -729,7 +743,7 @@ class TestDevice(TestCase):
         test_device_2 = Device(
             id="d2",
             patient_id="p1",
-            alias="Apple Watch",
+            name="Apple Watch",
             created_at=1629300943.9179766,
             device_type_id="dt2",
         )
@@ -737,7 +751,7 @@ class TestDevice(TestCase):
         test_patient = Patient(
             id="p1",
             created_at=1629300943.9179766,
-            code_name="patient1",
+            name="patient1",
             devices=DeviceSet(
                 [
                     test_device_1,
@@ -765,7 +779,7 @@ class TestDevice(TestCase):
         test_device_1 = Device(
             id="d1",
             patient_id="p1",
-            alias="Percept",
+            name="Percept",
             created_at=1629300943.9179766,
             device_type_id="dt1",
         )
@@ -773,14 +787,14 @@ class TestDevice(TestCase):
         test_patient_1 = Patient(
             id="p1",
             created_at=1629300943.9179766,
-            code_name="patient1",
+            name="patient1",
             devices=DeviceSet([test_device_1])
         )
 
         test_device_2 = Device(
             id="d2",
             patient_id="p1",
-            alias="Apple Watch",
+            name="Apple Watch",
             created_at=1629300943.9179766,
             device_type_id="dt2",
         )
@@ -788,7 +802,7 @@ class TestDevice(TestCase):
         test_patient_2 = Patient(
             id="p2",
             created_at=1629300943.9179766,
-            code_name="patient2",
+            name="patient2",
             devices=DeviceSet([test_device_2])
         )
 

--- a/tests/resources/test_patient.py
+++ b/tests/resources/test_patient.py
@@ -1,12 +1,12 @@
 """
-Tests for the V2 SDK Patient.
+Tests for fetching patient metadata
 
 """
 from unittest import TestCase, mock
 
 from runeq.config import Config
-from runeq.v2sdk.client import GraphClient
-from runeq.v2sdk.patient import (
+from runeq.resources.client import GraphClient
+from runeq.resources.patient import (
     Device, DeviceSet, Patient, PatientSet, get_all_devices, get_all_patients,
     get_device, get_patient, get_patient_devices
 )
@@ -107,11 +107,11 @@ class TestPatient(TestCase):
         test_patient = Patient(
             id="p1",
             created_at=1629300943.9179766,
-            name="patient1",
+            name="Patient 1",
             devices=DeviceSet()
         )
         self.assertEqual(
-            "Patient(id=p1, name=patient1)",
+            'Patient(id="p1", name="Patient 1")',
             repr(test_patient)
         )
 
@@ -640,7 +640,7 @@ class TestDevice(TestCase):
             device_type_id="dt1",
         )
         self.assertEqual(
-            "Device(id=1, name=Percept, patient_id=p1)",
+            'Device(id="1", name="Percept", patient_id="p1")',
             repr(test_device)
         )
 

--- a/tests/resources/test_stream.py
+++ b/tests/resources/test_stream.py
@@ -1,5 +1,5 @@
 """
-Tests for the V2 SDK Stream.
+Tests for fetching stream data.
 
 """
 from unittest import TestCase, mock

--- a/tests/resources/test_stream_metadata.py
+++ b/tests/resources/test_stream_metadata.py
@@ -1,5 +1,7 @@
 """
-Tests for the V2 SDK Stream.
+Tests for fetching stream metadata.
+
+TODO: add repr test
 
 """
 import json

--- a/tests/resources/test_stream_metadata.py
+++ b/tests/resources/test_stream_metadata.py
@@ -1,8 +1,6 @@
 """
 Tests for fetching stream metadata.
 
-TODO: add repr test
-
 """
 import json
 from unittest import TestCase, mock
@@ -80,6 +78,22 @@ class TestStreamType(TestCase):
             test_stream_type.description
         )
         self.assertEqual([], test_stream_type.dimensions)
+
+    def test_repr(self):
+        """
+        Test __repr__
+
+        """
+        test_stream_type = StreamType(
+            id="rotation",
+            name="Rotation",
+            description="Rotation rate (velocity) sampled in the time-domain.",
+            dimensions=[]
+        )
+        self.assertEqual(
+            'StreamType(id="rotation", name="Rotation")',
+            repr(test_stream_type)
+        )
 
     def test_get_all_stream_types(self):
         """
@@ -261,6 +275,27 @@ class TestStreamMetadata(TestCase):
         self.assertEqual(1648231560, test_stream.min_time)
         self.assertEqual(1648234860, test_stream.max_time)
         self.assertEqual({"category": "vitals"}, test_stream.parameters)
+
+    def test_repr(self):
+        """
+        Test __repr__
+
+        """
+        test_stream = StreamMetadata(
+            id="s1",
+            created_at=1629300943.9179766,
+            algorithm="a1",
+            device_id="d1",
+            patient_id="p1",
+            stream_type=None,
+            min_time=1648231560,
+            max_time=1648234860,
+            parameters={"category": "vitals"}
+        )
+        self.assertEqual(
+            'StreamMetadata(id="s1")',
+            repr(test_stream)
+        )
 
     def test_get_stream_metadata(self):
         """

--- a/tests/resources/test_user.py
+++ b/tests/resources/test_user.py
@@ -1,12 +1,12 @@
 """
-Tests for the V2 SDK User.
+Tests for fetching user metadata.
 
 """
 from unittest import TestCase, mock
 
 from runeq.config import Config
-from runeq.v2sdk.client import GraphClient
-from runeq.v2sdk.user import User, get_current_user
+from runeq.resources.client import GraphClient
+from runeq.resources.user import User, get_current_user
 
 
 class TestUser(TestCase):
@@ -54,13 +54,13 @@ class TestUser(TestCase):
         test_user = User(
             id="user1-id",
             created_at=1629300943.9179766,
-            name="user1",
+            name="User 1",
             active_org_id="org1-id",
-            active_org_name="org1",
+            active_org_name="Org 1",
         )
 
         self.assertEqual(
-            "User(id=user1-id, name=user1)",
+            'User(id="user1-id", name="User 1")',
             repr(test_user)
         )
 

--- a/tests/resources/test_user.py
+++ b/tests/resources/test_user.py
@@ -5,8 +5,8 @@ Tests for the V2 SDK User.
 from unittest import TestCase, mock
 
 from runeq.config import Config
-from runeq.resources.client import GraphClient
-from runeq.resources.user import User, get_current_user
+from runeq.v2sdk.client import GraphClient
+from runeq.v2sdk.user import User, get_current_user
 
 
 class TestUser(TestCase):
@@ -35,16 +35,34 @@ class TestUser(TestCase):
         test_user = User(
             id="user1-id",
             created_at=1629300943.9179766,
-            display_name="user1",
+            name="user1",
             active_org_id="org1-id",
-            active_org_display_name="org1",
+            active_org_name="org1",
         )
 
         self.assertEqual("user1-id", test_user.id)
         self.assertEqual(1629300943.9179766, test_user.created_at)
-        self.assertEqual("user1", test_user.display_name)
+        self.assertEqual("user1", test_user.name)
         self.assertEqual("org1-id", test_user.active_org_id)
-        self.assertEqual("org1", test_user.active_org_display_name)
+        self.assertEqual("org1", test_user.active_org_name)
+
+    def test_repr(self):
+        """
+        Test __repr__
+
+        """
+        test_user = User(
+            id="user1-id",
+            created_at=1629300943.9179766,
+            name="user1",
+            active_org_id="org1-id",
+            active_org_name="org1",
+        )
+
+        self.assertEqual(
+            "User(id=user1-id, name=user1)",
+            repr(test_user)
+        )
 
     def test_normalize_id(self):
         """
@@ -82,11 +100,11 @@ class TestUser(TestCase):
                 "user": {
                     "id": "user1-id",
                     "created_at": 1629300943.9179766,
-                    "display_name": "user1",
+                    "name": "user1",
                     "defaultMembership": {
                         "org": {
                             "id": "org1-id",
-                            "display_name": "org1"
+                            "name": "org1"
                         }
                     },
                     "email": "user1@email.com",
@@ -100,9 +118,9 @@ class TestUser(TestCase):
             {
                 "id": "user1-id",
                 "created_at": 1629300943.9179766,
-                "display_name": "user1",
+                "name": "user1",
                 "active_org_id": "org1-id",
-                "active_org_display_name": "org1",
+                "active_org_name": "org1",
                 "email": "user1@email.com",
             },
             user.to_dict(),


### PR DESCRIPTION
* Standardizing various different fields from the GraphQL API into an easier-to-remember "name"
* Creating a more compact `__repr__` , which includes the `.id` attribute and the `.name` attribute (if it exists). Overrode for `Device` only, because the patient ID is also important (device IDs are not globally unique; they're unique for a particular patient)
* Changing ItemSet `__str__` to `__repr__`. If `__str__` isn't defined, `__repr__` is used.