### PR TITLE
[DATA-586] Fix `**parameters` comment & imports

### DIFF
--- a/runeq/__init__.py
+++ b/runeq/__init__.py
@@ -3,7 +3,7 @@ The Rune Labs Standard Development Kit (SDK) for querying data from Rune
 APIs.
 
 """
-from . import stream
+from . import stream, resources
 from .config import Config
 from .resources.client import initialize
 
@@ -11,5 +11,6 @@ from .resources.client import initialize
 __all__ = [
     'Config',
     'initialize',
+    'resources',
     'stream',
 ]

--- a/runeq/resources/__init__.py
+++ b/runeq/resources/__init__.py
@@ -13,3 +13,14 @@ from the `V2 Stream API <https://docs.runelabs.io/stream/v2/index.html>`_,
 using a :class:`~runeq.resources.client.StreamClient`.
 
 """
+from . import client, common, org, patient, stream_metadata, stream, user
+
+__all__ = [
+    'client',
+    'common',
+    'org',
+    'patient',
+    'stream_metadata',
+    'stream',
+    'user'
+]

--- a/runeq/resources/client.py
+++ b/runeq/resources/client.py
@@ -12,7 +12,8 @@ from gql import gql
 from gql.transport.requests import RequestsHTTPTransport
 import requests
 
-from runeq import Config, errors
+from runeq.config import Config
+from runeq import errors
 
 # Error when a client is not initialized
 INITIALIZATION_ERROR = errors.InitializationError(

--- a/runeq/resources/stream_metadata.py
+++ b/runeq/resources/stream_metadata.py
@@ -835,7 +835,7 @@ def get_patient_stream_metadata(
             (e.g. heart_rate, step_count, etc).
         client: If specified, this client is used to fetch metadata from the
             API. Otherwise, the global GraphClient is used.
-        **parameters: A
+        **parameters: Key/value pairs that label the stream.
 
     """
     if not patient_id:

--- a/tests/resources/test_client.py
+++ b/tests/resources/test_client.py
@@ -34,7 +34,10 @@ class TestInitialize(TestCase):
             access_token_secret="bar",
         )
 
-        with self.assertRaisesRegex(errors.APIError, "404 NotFound"):
+        with self.assertRaisesRegex(
+            errors.APIError,
+            "401 InvalidAuthentication"
+        ):
             get_stream_data("stream_id").__next__()
 
     def test_init_with_client_keys(self):


### PR DESCRIPTION
[Jira Ticket](https://runelabs.atlassian.net/browse/DATA-586?atlOrigin=eyJpIjoiY2YzOTBlNWU5ZDk2NDM4NzgzNzA3ZjFlODM2YjgwY2UiLCJwIjoiaiJ9)

Note: I added an additional minor import change to this PR since it was quick. Essentially this import structure was erroring:
```
from runeq import initialize
initialize()

from runeq import resources
patients = resources.patient.get_all_patients()
print(patients.to_list())
```
with
```
    patients = resources.patient.get_all_patients()
AttributeError: module 'runeq.resources' has no attribute 'patient'
```
I figured it would be more flexible to support these import structures as well.