### PR TITLE
Study 305 Add projects and cohorts support - part 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ test:
 	# Run test suite
 	. $(VENV_ACTIVATE) && python3 -m unittest -v -k tests
 
+.PHONY: test-single
+test-single:
+	. $(VENV_ACTIVATE) && python -m unittest -k $(TEST_NAME)
+
 .PHONY: test-coverage
 test-coverage:
 	# Run tests wth coverage report

--- a/README.md
+++ b/README.md
@@ -32,24 +32,26 @@ Initialize a virtual environment, with dev requirements installed:
 
     make init
 
-Run tests:
+### Run tests
     
     make test
     # With coverage
     make test-coverage
 
-Lint:
+### Lint
 
     make lint
 
-Preview documentation:
+### Preview documentation
     
-    make -C docs preview
+    make build docs
 
-Build PyPI artifact:
+- This will build the documents in the `docs` directory. Open the `index.html` file in your browser to preview the documentation.
+
+### Build PyPI artifact:
 
     make build-dist
 
-Clean up ignored files/artifacts:
+### Clean up ignored files/artifacts
 
     make clean

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Initialize a virtual environment, with dev requirements installed:
     make test
     # With coverage
     make test-coverage
+    # For a single test
+    make test-single
+
 
 ### Lint
 
@@ -44,7 +47,7 @@ Initialize a virtual environment, with dev requirements installed:
 
 ### Preview documentation
     
-    make build docs
+    make build-docs
 
 - This will build the documents in the `docs` directory. Open the `index.html` file in your browser to preview the documentation.
 

--- a/docs/pages/resources.rst
+++ b/docs/pages/resources.rst
@@ -130,7 +130,7 @@ User Metadata
    :members:
    :inherited-members:
 
-Project Data
+Project Metadata
 -------------
 .. automodule:: runeq.resources.project
 

--- a/docs/pages/resources.rst
+++ b/docs/pages/resources.rst
@@ -129,3 +129,19 @@ User Metadata
    :special-members: __init__
    :members:
    :inherited-members:
+
+Project Data
+-------------
+.. automodule:: runeq.resources.project
+
+.. autofunction:: get_projects
+.. autofunction:: get_project
+
+.. autoclass:: Project
+   :special-members: __init__
+   :members:
+   :inherited-members:
+.. autoclass:: ProjectSet
+   :special-members: __init__
+   :members:
+   :inherited-members:

--- a/runeq/resources/project.py
+++ b/runeq/resources/project.py
@@ -13,8 +13,10 @@ class Project(ItemBase):
     """
     Metadata for a project.
 
-    A project contains a user defined group of patients. It has a user defined
-    start date which is used to track stream data metrics.
+    A project is a generic container for a group of patients
+    with workflow-related metadata: status, project type, description,
+    milestones dates, etc. Data availability QC metrics are computed
+    on a regular basis for all patients in a project.
 
     """
 

--- a/runeq/resources/project.py
+++ b/runeq/resources/project.py
@@ -84,7 +84,9 @@ class ProjectSet(ItemSet):
         return Project
 
 
-def get_project(project_id: str, client: Optional[GraphClient] = None) -> Project:
+def get_project(
+    project_id: str, client: Optional[GraphClient] = None
+) -> Project:
     """
     Get the project with the specified ID.
 

--- a/runeq/resources/project.py
+++ b/runeq/resources/project.py
@@ -1,0 +1,160 @@
+"""
+Fetch metadata about projects.
+
+"""
+
+from typing import Iterable, Optional, Type
+
+from .client import GraphClient, global_graph_client
+from .common import ItemBase, ItemSet
+
+
+class Project(ItemBase):
+    """
+    Metadata for an project.
+
+    """
+
+    def __init__(
+        self,
+        id: str,
+        title: str,
+        created_at: float,
+        **attributes
+    ):
+        """
+        Initialize with metadata.
+
+        Args:
+            id: ID of the project
+            title: Human-readable name
+            created_at: When the organization was created (unix timestamp)
+            **attributes: Other attributes associated with the project
+
+        """
+        # Update to include required attributes
+        self.title = title
+        self.created_at = created_at
+
+        super().__init__(
+            id=id,
+            title=title,
+            created_at=created_at,
+            **attributes,
+        )
+
+
+class ProjectSet(ItemSet):
+    """
+    A collection of Projects.
+
+    """
+
+    def __init__(self, items: Iterable[Project] = ()):
+        """
+        Initialize with Projects.
+
+        """
+        super().__init__(items=items)
+
+    @property
+    def _item_class(self) -> Type[ItemBase]:
+        """
+        Instance type of items in this set.
+
+        """
+        return Project
+
+
+def get_project(
+    project_id: str, client: Optional[GraphClient] = None
+) -> Project:
+    """
+    Get the project with the specified ID.
+
+    Args:
+        project_id: Project ID
+        client: If specified, this client is used to fetch metadata from the
+            API. Otherwise, the global GraphClient is used.
+
+    """
+    client = client or global_graph_client()
+    query = '''
+        query getProject($project_id: ID) {
+            project (projectId: $project_id) {
+                id
+                created_at
+                title
+                description
+                project_status
+                project_type
+                started_at
+                created_by
+            }
+        }
+    '''
+
+    result = client.execute(
+        statement=query,
+        project_id=project_id
+    )
+
+    project_attrs = result["project"]
+    return Project(**project_attrs)
+
+
+def get_projects(client: Optional[GraphClient] = None) -> ProjectSet:
+    """
+    Get all the projects that the current user has access to.
+
+    Args:
+        client: If specified, this client is used to fetch metadata from the
+            API. Otherwise, the global GraphClient is used.
+
+    """
+    client = client or global_graph_client()
+    query = '''
+        query($cursor: DateTimeUUIDCursor) {
+            org {
+                id
+                projectList(cursor: $cursor) {
+                    projects {
+                        id,
+                        title,
+                        status,
+                        type,
+                        created_at: createdAt,
+                        updated_at: updatedAt,
+                        started_at: startedAt,
+                        created_by: createdBy,
+                        updated_by: updatedBy
+                    }
+                    pageInfo {
+                        endCursor
+                    }
+                }
+            }
+        }
+    '''
+
+    next_cursor = None
+    project_set = ProjectSet()
+
+    # Use cursor to page through all org memberships
+    while True:
+        result = client.execute(
+            statement=query,
+            cursor=next_cursor
+        )
+        project_list = result.get("org", {}).get("projectList", {})
+
+        for project in project_list.get("projects", []):
+            project = Project(**project)
+            project_set.add(project)
+
+        # endCursor is None when there are no more pages of data
+        next_cursor = project_list.get("pageInfo", {}).get("endCursor")
+        if not next_cursor:
+            break
+
+    return project_set

--- a/runeq/resources/project.py
+++ b/runeq/resources/project.py
@@ -11,7 +11,10 @@ from .common import ItemBase, ItemSet
 
 class Project(ItemBase):
     """
-    Metadata for an project.
+    Metadata for a project.
+
+    A project contains a user defined group of patients. It has a user defined
+    start date which is used to track stream data metrics.
 
     """
 
@@ -34,14 +37,14 @@ class Project(ItemBase):
         Args:
             id: ID of the project
             title: Human-readable name
-            created_at: When the project was created (unix timestamp)
-            status: Status of the project,
-            type: Type of project,
-            started_at: Time the project started (unix timestamp),
-            created_at: Time the project was created (unix timestamp),
-            created_by: UserID of who created the project,
-            updated_at: Time the project was last updated (unix timestamp),
-            updated_by: UserID of who updated the project,
+            status: Status of the project
+            type: Type of project. Possible types include: EXPLORATORY,
+                CLINICAL_TRIAL,RETROSPECTIVE_STUDY, PROSPECTIVE_STUDY, SANDBOX
+            started_at: Time the project started (unix timestamp)
+            created_at: Time the project was created (unix timestamp)
+            created_by: Display name of who created the project
+            updated_at: Time the project was last updated (unix timestamp)
+            updated_by: Display name of who updated the project
             **attributes: Other attributes associated with the project
 
         """
@@ -106,7 +109,7 @@ def get_project(
     client = client or global_graph_client()
     query = """
         query getProject($project_id: ID) {
-            project (projectId: $project_id) {
+            project (id: $project_id) {
                 id,
                 title,
                 status,

--- a/runeq/resources/project.py
+++ b/runeq/resources/project.py
@@ -29,12 +29,19 @@ class Project(ItemBase):
         **attributes
     ):
         """
-        Initialize with metadata.
+        Initialize with data.
 
         Args:
             id: ID of the project
             title: Human-readable name
-            created_at: When the organization was created (unix timestamp)
+            created_at: When the project was created (unix timestamp)
+            status: Status of the project,
+            type: Type of project,
+            started_at: Time the project started (unix timestamp),
+            created_at: Time the project was created (unix timestamp),
+            created_by: UserID of who created the project,
+            updated_at: Time the project was last updated (unix timestamp),
+            updated_by: UserID of who updated the project,
             **attributes: Other attributes associated with the project
 
         """
@@ -158,7 +165,7 @@ def get_projects(client: Optional[GraphClient] = None) -> ProjectSet:
     next_cursor = None
     project_set = ProjectSet()
 
-    # Use cursor to page through all org memberships
+    # Use cursor to page through all projects
     while True:
         result = client.execute(statement=query, cursor=next_cursor)
         project_list = result.get("org", {}).get("projectList", {})

--- a/tests/resources/test_project.py
+++ b/tests/resources/test_project.py
@@ -14,7 +14,6 @@ class TestProject(TestCase):
     Unit tests for the Project class.
 
     """
-
     def setUp(self):
         """
         Set up mock graph client for testing.
@@ -29,22 +28,27 @@ class TestProject(TestCase):
         Test attributes for an initialized Project.
 
         """
-        test_org = Project(
+        test_project = Project(
             id="proj1-id",
             created_at=1630515986.9949625,
             updated_at=1630515986.9949625,
             title="Project 1",
             description="Test description.",
-            created_by="user-id-1",
-            updated_by="user-id-1",
+            created_by="user-1",
+            updated_by="user-1",
             started_at=1630515986.9949625,
             status="ACTIVE",
             type="SANDBOX",
         )
 
-        self.assertEqual("proj1-id", test_org.id)
-        self.assertEqual(1630515986.9949625, test_org.created_at)
-        self.assertEqual("Project 1", test_org.title)
+        self.assertEqual("proj1-id", test_project.id)
+        self.assertEqual(1630515986.9949625, test_project.created_at)
+        self.assertEqual("Project 1", test_project.title)
+        self.assertEqual(1630515986.9949625, test_project.updated_at)
+        self.assertEqual("user-1", test_project.created_by)
+        self.assertEqual("user-1", test_project.updated_by)
+        self.assertEqual("ACTIVE", test_project.status)
+        self.assertEqual("SANDBOX", test_project.type)
 
     def test_get_project(self):
         """

--- a/tests/resources/test_project.py
+++ b/tests/resources/test_project.py
@@ -7,7 +7,6 @@ from unittest import TestCase, mock
 from runeq.config import Config
 from runeq.resources.client import GraphClient
 from runeq.resources.project import Project, get_project, get_projects
-from runeq.resources.client import initialize
 
 
 class TestProject(TestCase):
@@ -22,10 +21,7 @@ class TestProject(TestCase):
 
         """
         self.mock_client = GraphClient(
-            Config(
-                client_key_id="test",
-                client_access_key="config"
-            )
+            Config(client_key_id="test", client_access_key="config")
         )
 
     def test_attributes(self):
@@ -34,14 +30,21 @@ class TestProject(TestCase):
 
         """
         test_org = Project(
-            id="project1-id",
-            created_at=1629300943.9179766,
-            title="project1",
+            id="proj1-id",
+            created_at=1630515986.9949625,
+            updated_at=1630515986.9949625,
+            title="Project 1",
+            description="Test description.",
+            created_by="user-id-1",
+            updated_by="user-id-1",
+            started_at=1630515986.9949625,
+            status="ACTIVE",
+            type="SANDBOX",
         )
 
-        self.assertEqual("project1-id", test_org.id)
-        self.assertEqual(1629300943.9179766, test_org.created_at)
-        self.assertEqual("project1", test_org.title)
+        self.assertEqual("proj1-id", test_org.id)
+        self.assertEqual(1630515986.9949625, test_org.created_at)
+        self.assertEqual("Project 1", test_org.title)
 
     def test_get_project(self):
         """
@@ -52,19 +55,17 @@ class TestProject(TestCase):
         example_project = {
             "id": "proj1-id",
             "created_at": 1630515986.9949625,
+            "updated_at": 1630515986.9949625,
             "title": "Project 1",
             "description": "Test description.",
             "created_by": "user-id-1",
+            "updated_by": "user-id-1",
             "started_at": 1630515986.9949625,
             "status": "ACTIVE",
-            "project_type": "SANDBOX"
+            "type": "SANDBOX",
         }
 
-        self.mock_client.execute.side_effect = [
-            {
-                "project": example_project
-            }
-        ]
+        self.mock_client.execute.side_effect = [{"project": example_project}]
 
         project = get_project("proj1-id", client=self.mock_client)
 
@@ -79,85 +80,58 @@ class TestProject(TestCase):
 
         """
         self.mock_client.execute = mock.Mock()
+        projects_expected = [
+            {
+                "id": "proj1-id",
+                "created_at": 1630515986.9949625,
+                "title": "Project 1",
+                "description": "Test description.",
+                "created_by": "user-id-1",
+                "started_at": 1630515986.9949625,
+                "status": "ACTIVE",
+                "updated_at": 1630515986.9949625,
+                "type": "SANDBOX",
+                "updated_by": "user-id-1",
+            },
+            {
+                "id": "proj2-id",
+                "created_at": 1630517987.9949625,
+                "title": "Project 2",
+                "description": "Test description 2.",
+                "created_by": "user-id-2",
+                "started_at": 1630517986.9949625,
+                "updated_at": 1630515986.9949625,
+                "status": "ACTIVE",
+                "type": "SANDBOX",
+                "updated_by": "user-id-1",
+            },
+            {
+                "id": "proj3-id",
+                "created_at": 1630519988.9949625,
+                "title": "Project 3",
+                "description": "Test description 3.",
+                "created_by": "user-id-3",
+                "started_at": 1630519986.9949625,
+                "updated_at": 1630515986.9949625,
+                "status": "ACTIVE",
+                "type": "SANDBOX",
+                "updated_by": "user-id-1",
+            },
+        ]
         self.mock_client.execute.return_value = {
-            'org': {
-                'id': 'org-rune,org', 
-                'projectList': {
-                    'projects': [
-                        {
-                            "id": "proj1-id",
-                            "created_at": 1630515986.9949625,
-                            "title": "Project 1",
-                            "description": "Test description.",
-                            "created_by": "user-id-1",
-                            "started_at": 1630515986.9949625,
-                            "status": "ACTIVE",
-                            "project_type": "SANDBOX"
-                        },
-                        {
-                            "id": "proj2-id",
-                            "created_at": 1630517986.9949625,
-                            "title": "Project 2",
-                            "description": "Test description 2.",
-                            "created_by": "user-id-2",
-                            "started_at": 1630517986.9949625,
-                            "status": "ACTIVE",
-                            "project_type": "SANDBOX"
-
-                        },
-                        {
-                            "id": "proj3-id",
-                            "created_at": 1630519986.9949625,
-                            "title": "Project 3",
-                            "description": "Test description 3.",
-                            "created_by": "user-id-3",
-                            "started_at": 1630519986.9949625,
-                            "status": "ACTIVE",
-                            "project_type": "SANDBOX"
-                        },
-                    ],
-                    'pageInfo': {
-                        'endCursor': None
-                    }
-                }
+            "org": {
+                "id": "org-rune,org",
+                "projectList": {
+                    "projects": projects_expected,
+                    "pageInfo": {"endCursor": None},
+                },
             }
         }
 
         projects = get_projects(client=self.mock_client)
 
         self.assertEqual(
-            [
-                {
-                    "id": "proj1-id",
-                    "created_at": 1630515986.9949625,
-                    "title": "Project 1",
-                    "description": "Test description.",
-                    "created_by": "user-id-1",
-                    "started_at": 1630515986.9949625,
-                    "status": "ACTIVE",
-                    "project_type": "SANDBOX"
-                },
-                {
-                    "id": "proj2-id",
-                    "created_at": 1630517986.9949625,
-                    "title": "Project 2",
-                    "description": "Test description 2.",
-                    "created_by": "user-id-2",
-                    "started_at": 1630517986.9949625,
-                    "status": "ACTIVE",
-                    "project_type": "SANDBOX"
-                },
-                {
-                    "id": "proj3-id",
-                    "created_at": 1630519986.9949625,
-                    "title": "Project 3",
-                    "description": "Test description 3.",
-                    "created_by": "user-id-3",
-                    "started_at": 1630519986.9949625,
-                    "status": "ACTIVE",
-                    "project_type": "SANDBOX"
-                }
-            ],
+            projects_expected,
             projects.to_list(),
         )
 
@@ -167,61 +141,62 @@ class TestProject(TestCase):
         page through projects.
 
         """
+        project_1 = {
+            "id": "proj1-id",
+            "created_at": 1630515986.9949625,
+            "updated_at": 1630515986.9949625,
+            "title": "Project 1",
+            "description": "Test description.",
+            "created_by": "user-id-1",
+            "started_at": 1630515986.9949625,
+            "status": "ACTIVE",
+            "type": "SANDBOX",
+            "created_by": "user-id-1",
+            "updated_by": "user-id-1",
+        }
+        project_2 = {
+            "id": "proj2-id",
+            "created_at": 1630517986.9949625,
+            "updated_at": 1630515986.9949625,
+            "title": "Project 2",
+            "description": "Test description 2.",
+            "created_by": "user-id-2",
+            "started_at": 1630517986.9949625,
+            "status": "ACTIVE",
+            "type": "SANDBOX",
+            "updated_by": "user-id-1",
+        }
+        project_3 = {
+            "id": "proj3-id",
+            "created_at": 1630519986.9949625,
+            "updated_at": 1630515986.9949625,
+            "title": "Project 3",
+            "description": "Test description 3.",
+            "created_by": "user-id-3",
+            "started_at": 1630519986.9949625,
+            "status": "ACTIVE",
+            "type": "SANDBOX",
+            "updated_by": "user-id-1",
+        }
+
         self.mock_client.execute = mock.Mock()
         self.mock_client.execute.side_effect = [
             {
-                'org': {
-                    'id': 'org-rune,org', 
-                    'projectList': {
-                        'projects': [
-                            {
-                                "id": "proj1-id",
-                                "created_at": 1630515986.9949625,
-                                "title": "Project 1",
-                                "description": "Test description.",
-                                "created_by": "user-id-1",
-                                "started_at": 1630515986.9949625,
-                                "status": "ACTIVE",
-                                "project_type": "SANDBOX"
-                            },
-                            {
-                                "id": "proj2-id",
-                                "created_at": 1630517986.9949625,
-                                "title": "Project 2",
-                                "description": "Test description 2.",
-                                "created_by": "user-id-2",
-                                "started_at": 1630517986.9949625,
-                                "status": "ACTIVE",
-                                "project_type": "SANDBOX"
-
-                            },
-                        ],
-                        "pageInfo": {
-                            "endCursor": "test_check_next"
-                        },
-                    }
+                "org": {
+                    "id": "org-rune,org",
+                    "projectList": {
+                        "projects": [project_1, project_2],
+                        "pageInfo": {"endCursor": "test_check_next"},
+                    },
                 }
             },
             {
-                'org': {
-                    'id': 'org-rune,org', 
-                    'projectList': {
-                        'projects': [
-                            {
-                                "id": "proj3-id",
-                                "created_at": 1630519986.9949625,
-                                "title": "Project 3",
-                                "description": "Test description 3.",
-                                "created_by": "user-id-3",
-                                "started_at": 1630519986.9949625,
-                                "status": "ACTIVE",
-                                "project_type": "SANDBOX"
-                            },
-                        ],
-                        "pageInfo": {
-                            "endCursor": None
-                        },
-                    }
+                "org": {
+                    "id": "org-rune,org",
+                    "projectList": {
+                        "projects": [project_3],
+                        "pageInfo": {"endCursor": None},
+                    },
                 }
             },
         ]
@@ -229,38 +204,6 @@ class TestProject(TestCase):
         projects = get_projects(client=self.mock_client)
 
         self.assertEqual(
-            [
-                {
-                    "id": "proj1-id",
-                    "created_at": 1630515986.9949625,
-                    "title": "Project 1",
-                    "description": "Test description.",
-                    "created_by": "user-id-1",
-                    "started_at": 1630515986.9949625,
-                    "status": "ACTIVE",
-                    "project_type": "SANDBOX"
-                },
-                {
-                    "id": "proj2-id",
-                    "created_at": 1630517986.9949625,
-                    "title": "Project 2",
-                    "description": "Test description 2.",
-                    "created_by": "user-id-2",
-                    "started_at": 1630517986.9949625,
-                    "status": "ACTIVE",
-                    "project_type": "SANDBOX"
-                },
-                {
-                    "id": "proj3-id",
-                    "created_at": 1630519986.9949625,
-                    "title": "Project 3",
-                    "description": "Test description 3.",
-                    "created_by": "user-id-3",
-                    "started_at": 1630519986.9949625,
-                    "status": "ACTIVE",
-                    "project_type": "SANDBOX"
-                }
-            ],
+            [project_1, project_2, project_3],
             projects.to_list(),
         )
-

--- a/tests/resources/test_project.py
+++ b/tests/resources/test_project.py
@@ -1,0 +1,266 @@
+"""
+Tests for fetching project data.
+
+"""
+from unittest import TestCase, mock
+
+from runeq.config import Config
+from runeq.resources.client import GraphClient
+from runeq.resources.project import Project, get_project, get_projects
+from runeq.resources.client import initialize
+
+
+class TestProject(TestCase):
+    """
+    Unit tests for the Project class.
+
+    """
+
+    def setUp(self):
+        """
+        Set up mock graph client for testing.
+
+        """
+        self.mock_client = GraphClient(
+            Config(
+                client_key_id="test",
+                client_access_key="config"
+            )
+        )
+
+    def test_attributes(self):
+        """
+        Test attributes for an initialized Project.
+
+        """
+        test_org = Project(
+            id="project1-id",
+            created_at=1629300943.9179766,
+            title="project1",
+        )
+
+        self.assertEqual("project1-id", test_org.id)
+        self.assertEqual(1629300943.9179766, test_org.created_at)
+        self.assertEqual("project1", test_org.title)
+
+    def test_get_project(self):
+        """
+        Test get project for specified project_id.
+
+        """
+        self.mock_client.execute = mock.Mock()
+        example_project = {
+            "id": "proj1-id",
+            "created_at": 1630515986.9949625,
+            "title": "Project 1",
+            "description": "Test description.",
+            "created_by": "user-id-1",
+            "started_at": 1630515986.9949625,
+            "status": "ACTIVE",
+            "project_type": "SANDBOX"
+        }
+
+        self.mock_client.execute.side_effect = [
+            {
+                "project": example_project
+            }
+        ]
+
+        project = get_project("proj1-id", client=self.mock_client)
+
+        self.assertEqual(
+            example_project,
+            project.to_dict(),
+        )
+
+    def test_get_projects_basic(self):
+        """
+        Test get projects for the initialized user.
+
+        """
+        self.mock_client.execute = mock.Mock()
+        self.mock_client.execute.return_value = {
+            'org': {
+                'id': 'org-rune,org', 
+                'projectList': {
+                    'projects': [
+                        {
+                            "id": "proj1-id",
+                            "created_at": 1630515986.9949625,
+                            "title": "Project 1",
+                            "description": "Test description.",
+                            "created_by": "user-id-1",
+                            "started_at": 1630515986.9949625,
+                            "status": "ACTIVE",
+                            "project_type": "SANDBOX"
+                        },
+                        {
+                            "id": "proj2-id",
+                            "created_at": 1630517986.9949625,
+                            "title": "Project 2",
+                            "description": "Test description 2.",
+                            "created_by": "user-id-2",
+                            "started_at": 1630517986.9949625,
+                            "status": "ACTIVE",
+                            "project_type": "SANDBOX"
+
+                        },
+                        {
+                            "id": "proj3-id",
+                            "created_at": 1630519986.9949625,
+                            "title": "Project 3",
+                            "description": "Test description 3.",
+                            "created_by": "user-id-3",
+                            "started_at": 1630519986.9949625,
+                            "status": "ACTIVE",
+                            "project_type": "SANDBOX"
+                        },
+                    ],
+                    'pageInfo': {
+                        'endCursor': None
+                    }
+                }
+            }
+        }
+
+        projects = get_projects(client=self.mock_client)
+
+        self.assertEqual(
+            [
+                {
+                    "id": "proj1-id",
+                    "created_at": 1630515986.9949625,
+                    "title": "Project 1",
+                    "description": "Test description.",
+                    "created_by": "user-id-1",
+                    "started_at": 1630515986.9949625,
+                    "status": "ACTIVE",
+                    "project_type": "SANDBOX"
+                },
+                {
+                    "id": "proj2-id",
+                    "created_at": 1630517986.9949625,
+                    "title": "Project 2",
+                    "description": "Test description 2.",
+                    "created_by": "user-id-2",
+                    "started_at": 1630517986.9949625,
+                    "status": "ACTIVE",
+                    "project_type": "SANDBOX"
+                },
+                {
+                    "id": "proj3-id",
+                    "created_at": 1630519986.9949625,
+                    "title": "Project 3",
+                    "description": "Test description 3.",
+                    "created_by": "user-id-3",
+                    "started_at": 1630519986.9949625,
+                    "status": "ACTIVE",
+                    "project_type": "SANDBOX"
+                }
+            ],
+            projects.to_list(),
+        )
+
+    def test_get_projects_pagination(self):
+        """
+        Test get projects for the initialized user, where the user has to
+        page through projects.
+
+        """
+        self.mock_client.execute = mock.Mock()
+        self.mock_client.execute.side_effect = [
+            {
+                'org': {
+                    'id': 'org-rune,org', 
+                    'projectList': {
+                        'projects': [
+                            {
+                                "id": "proj1-id",
+                                "created_at": 1630515986.9949625,
+                                "title": "Project 1",
+                                "description": "Test description.",
+                                "created_by": "user-id-1",
+                                "started_at": 1630515986.9949625,
+                                "status": "ACTIVE",
+                                "project_type": "SANDBOX"
+                            },
+                            {
+                                "id": "proj2-id",
+                                "created_at": 1630517986.9949625,
+                                "title": "Project 2",
+                                "description": "Test description 2.",
+                                "created_by": "user-id-2",
+                                "started_at": 1630517986.9949625,
+                                "status": "ACTIVE",
+                                "project_type": "SANDBOX"
+
+                            },
+                        ],
+                        "pageInfo": {
+                            "endCursor": "test_check_next"
+                        },
+                    }
+                }
+            },
+            {
+                'org': {
+                    'id': 'org-rune,org', 
+                    'projectList': {
+                        'projects': [
+                            {
+                                "id": "proj3-id",
+                                "created_at": 1630519986.9949625,
+                                "title": "Project 3",
+                                "description": "Test description 3.",
+                                "created_by": "user-id-3",
+                                "started_at": 1630519986.9949625,
+                                "status": "ACTIVE",
+                                "project_type": "SANDBOX"
+                            },
+                        ],
+                        "pageInfo": {
+                            "endCursor": None
+                        },
+                    }
+                }
+            },
+        ]
+
+        projects = get_projects(client=self.mock_client)
+
+        self.assertEqual(
+            [
+                {
+                    "id": "proj1-id",
+                    "created_at": 1630515986.9949625,
+                    "title": "Project 1",
+                    "description": "Test description.",
+                    "created_by": "user-id-1",
+                    "started_at": 1630515986.9949625,
+                    "status": "ACTIVE",
+                    "project_type": "SANDBOX"
+                },
+                {
+                    "id": "proj2-id",
+                    "created_at": 1630517986.9949625,
+                    "title": "Project 2",
+                    "description": "Test description 2.",
+                    "created_by": "user-id-2",
+                    "started_at": 1630517986.9949625,
+                    "status": "ACTIVE",
+                    "project_type": "SANDBOX"
+                },
+                {
+                    "id": "proj3-id",
+                    "created_at": 1630519986.9949625,
+                    "title": "Project 3",
+                    "description": "Test description 3.",
+                    "created_by": "user-id-3",
+                    "started_at": 1630519986.9949625,
+                    "status": "ACTIVE",
+                    "project_type": "SANDBOX"
+                }
+            ],
+            projects.to_list(),
+        )
+


### PR DESCRIPTION
This PR adds support to access all the project in a user's default organization, and a single project using the project id as an input parameter. It also updates the documentation to reflect this.

https://runelabs.atlassian.net/browse/STUDY-305

This was tested manually and with unit tests.