### PR TITLE
Update Config example to use user API token

### DIFF
--- a/runeq/config.py
+++ b/runeq/config.py
@@ -56,8 +56,10 @@ class Config:
             >>> cfg = Config('./example_config.yaml')
             # Load from a specified YAML file
 
-            >>> cfg = Config(client_key_id='foo', client_access_key='bar')
-            # Set values using keyword arguments
+            >>> cfg = Config(access_token_id='foo', access_token_secret='bar')
+            # Set values using keyword arguments. This can be used with any valid
+            # combination of config options; the example above sets a user
+            # access token.
 
         """
         self.graph_url = 'https://graph.runelabs.io'

--- a/runeq/config.py
+++ b/runeq/config.py
@@ -57,9 +57,9 @@ class Config:
             # Load from a specified YAML file
 
             >>> cfg = Config(access_token_id='foo', access_token_secret='bar')
-            # Set values using keyword arguments. This can be used with any valid
-            # combination of config options; the example above sets a user
-            # access token.
+            # Set values using keyword arguments. This can be used with any
+            # valid combination of config options; the example above sets a
+            # user access token.
 
         """
         self.graph_url = 'https://graph.runelabs.io'


### PR DESCRIPTION
Most people use user access tokens with the SDK, rather than client keys (which are scoped to a single patient). Updating the example documentation to reflect that.