### PR TITLE
Bump library version to v0.11.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('requirements/common.txt', 'r') as r:
 
 setup(
     name=package_name,
-    version='0.10.0',
+    version='0.11.0',
     author='Rune Labs',
     maintainer_email='support@runelabs.io',
     description='Query data from Rune Labs APIs',


### PR DESCRIPTION
Preparing to release a new version of the library, with https://github.com/rune-labs/runeq-python/pull/38