### PR TITLE
[SW-2047, SW-2178] Add ability to switch orgs

### DIFF
--- a/docs/pages/quickstart.rst
+++ b/docs/pages/quickstart.rst
@@ -6,12 +6,16 @@ Quickstart
 Prerequisites
 -------------
 
-API Credentials
-***************
-
 To access Rune's APIs, you will need to obtain API credentials.
 For multi-patient analyses, we recommended using **user access tokens**.
-These provide access to all the user's allowed resources.
+
+.. note::
+    If you belong to multiple organizations, note that only one organization is "active" at a time.
+    You can only access resources that belong to your active organization. This impacts both what is
+    returned by the SDK *and* what you see in the `Rune web portal <https://app.runelabs.io>`_.
+
+    You can change your active organization through code (see :ref:`quickstart_init`) or
+    in the `Rune web portal <https://app.runelabs.io>`_ (click on the profile icon, in the top right corner).
 
 To create a new access token:
 
@@ -28,16 +32,6 @@ with this library.
 It is highly recommended that you rotate your access tokens every 3-6 months,
 by creating a new token and deactivating the old one. Store your access tokens
 securely, and do not share them.
-
-Multiple Organizations
-**********************
-
-For users who are members of multiple organizations, note that
-user access tokens only operate within the context of the organization that
-is **currently active**. To switch your active organization, log in to
-the `Rune web portal <https://app.runelabs.io>`_ and click on the profile icon
-in the top right corner. If you are a member of multiple organizations, the
-profile icon's dropdown menu will have an option to switch your organization.
 
 .. _quickstart_config:
 
@@ -77,7 +71,8 @@ you're rotating your access token, getting set up on a different computer, etc).
 Initialization
 --------------
 
-To get started with the library, use :class:`~runeq.initialize`:
+To get started with the library, use :class:`~runeq.initialize`. This loads credentials from your
+configuration file (see :ref:`quickstart_config`).
 
 .. code-block:: python
 
@@ -85,9 +80,7 @@ To get started with the library, use :class:`~runeq.initialize`:
 
     initialize()
 
-This loads credentials from your configuration file (see :ref:`quickstart_config`).
-
-You can see information about your authenticated user:
+To see information about your authenticated user:
 
 .. code-block:: python
 
@@ -95,7 +88,8 @@ You can see information about your authenticated user:
 
     my_user = get_current_user()
     print(my_user)
-    print('Active Org:', my_user.active_org_name)
+    print('Active Org Name:', my_user.active_org_name)
+    print('Active Org ID:', my_user.active_org_id)
 
     # Fetch all the organizations that your user belongs to
     print('My Orgs')
@@ -103,18 +97,15 @@ You can see information about your authenticated user:
     for org in all_orgs:
         print(org)
 
-.. note::
-    If you belong to multiple organizations, note that only one organization is "active" at a time.
-    You can only access resources that belong to your active organization. This impacts both what is
-    returned by the SDK _and_ what you see when you log in to the Rune web portal.
+Change Active Org
+*****************
 
-    You can change your active org through the SDK (see below) or in Rune's web portal.
+To set your user's active org:
 
 .. code-block:: python
 
     from runeq.resources.org import set_active_org
 
-    # set_active_org accepts an org ID (as shown) or an Org instance
     org_id = "aa0c21f97d6a0593b0a247c68f015d68b787655e"
     set_active_org(org_id)
 
@@ -126,7 +117,7 @@ Explore Metadata
 
 After initializing the library, you can fetch metadata about various resources.
 
-For example, you can fetch metadata about all the patients you have access to:
+For example, you can fetch metadata about all the patients in your active org:
 
 .. code-block:: python
 
@@ -142,8 +133,8 @@ For example, you can fetch metadata about all the patients you have access to:
         print('')
 
 
-:class:`~runeq.resources.patient.get_all_patients` returns a :class:`~runeq.resources.patient.PatientSet`,
-which can be serialized as a list of dictionaries, e.g. to save the metadata to a file:
+:class:`~runeq.resources.patient.get_all_patients` returns a :class:`~runeq.resources.patient.PatientSet`.
+This object can be serialized as a list of dictionaries, e.g. to save the metadata to a file:
 
 .. code-block:: python
 

--- a/docs/pages/quickstart.rst
+++ b/docs/pages/quickstart.rst
@@ -6,6 +6,9 @@ Quickstart
 Prerequisites
 -------------
 
+API Credentials
+***************
+
 To access Rune's APIs, you will need to obtain API credentials.
 For multi-patient analyses, we recommended using **user access tokens**.
 
@@ -14,7 +17,7 @@ For multi-patient analyses, we recommended using **user access tokens**.
     You can only access resources that belong to your active organization. This impacts both what is
     returned by the SDK *and* what you see in the `Rune web portal <https://app.runelabs.io>`_.
 
-    You can change your active organization through code (see :ref:`quickstart_init`) or
+    You can change your active organization through code (see :ref:`change_active_org`) or
     in the `Rune web portal <https://app.runelabs.io>`_ (click on the profile icon, in the top right corner).
 
 To create a new access token:
@@ -36,7 +39,7 @@ securely, and do not share them.
 .. _quickstart_config:
 
 Configuration Setup
--------------------
+*******************
 
 ``runeq`` uses a `YAML <https://yaml.org/>`_-formatted file to manage configuration
 settings (e.g. API credentials). The easiest way to set up this configuration is via
@@ -88,29 +91,36 @@ To see information about your authenticated user:
 
     my_user = get_current_user()
     print(my_user)
-    print('Active Org Name:', my_user.active_org_name)
-    print('Active Org ID:', my_user.active_org_id)
+    print('Active Org:', my_user.active_org_name)
 
-    # Fetch all the organizations that your user belongs to
-    print('My Orgs')
-    all_orgs = get_orgs()
-    for org in all_orgs:
-        print(org)
+Usage
+-----
+
+.. _change_active_org:
 
 Change Active Org
 *****************
 
-To set your user's active org:
+To get metadata about all the organizations that you belong to:
+
+.. code-block:: python
+
+    from runeq.resources.org import get_orgs
+
+    all_orgs = get_orgs()
+    for org in all_orgs:
+        print(org)
+
+You can set your active organization using an org ID:
 
 .. code-block:: python
 
     from runeq.resources.org import set_active_org
 
     org_id = "aa0c21f97d6a0593b0a247c68f015d68b787655e"
-    set_active_org(org_id)
+    active_org = set_active_org(org_id)
+    print('Active Org:', active_org.name)
 
-Usage
------
 
 Explore Metadata
 ****************

--- a/docs/pages/quickstart.rst
+++ b/docs/pages/quickstart.rst
@@ -87,16 +87,7 @@ To get started with the library, use :class:`~runeq.initialize`:
 
 This loads credentials from your configuration file (see :ref:`quickstart_config`).
 
-Usage
------
-
-Explore Metadata
-****************
-
-After initializing the library, you can fetch metadata about various resources.
-
-For example, you can get information about your user, based on the authentication
-credentials:
+You can see information about your authenticated user:
 
 .. code-block:: python
 
@@ -106,7 +97,36 @@ credentials:
     print(my_user)
     print('Active Org:', my_user.active_org_name)
 
-You can also fetch metadata about all the patients you have access to:
+    # Fetch all the organizations that your user belongs to
+    print('My Orgs')
+    all_orgs = get_orgs()
+    for org in all_orgs:
+        print(org)
+
+.. note::
+    If you belong to multiple organizations, note that only one organization is "active" at a time.
+    You can only access resources that belong to your active organization. This impacts both what is
+    returned by the SDK _and_ what you see when you log in to the Rune web portal.
+
+    You can change your active org through the SDK (see below) or in Rune's web portal.
+
+.. code-block:: python
+
+    from runeq.resources.org import set_active_org
+
+    # set_active_org accepts an org ID (as shown) or an Org instance
+    org_id = "aa0c21f97d6a0593b0a247c68f015d68b787655e"
+    set_active_org(org_id)
+
+Usage
+-----
+
+Explore Metadata
+****************
+
+After initializing the library, you can fetch metadata about various resources.
+
+For example, you can fetch metadata about all the patients you have access to:
 
 .. code-block:: python
 

--- a/docs/pages/resources.rst
+++ b/docs/pages/resources.rst
@@ -67,6 +67,8 @@ Organization Metadata
 
 .. autofunction:: get_org
 .. autofunction:: get_orgs
+.. autofunction:: set_active_org
+.. autofunction:: active_org
 
 .. autoclass:: Org
    :special-members: __init__
@@ -172,7 +174,7 @@ Cohorts
    :special-members: __init__
    :members:
    :inherited-members:
-   .. autoclass:: CohortPatientMetadata
+.. autoclass:: CohortPatientMetadata
    :special-members: __init__
    :members:
    :inherited-members:

--- a/runeq/resources/org.py
+++ b/runeq/resources/org.py
@@ -210,7 +210,7 @@ def set_active_org(
             API. Otherwise, the global GraphClient is used.
 
     Returns:
-        The active organization (
+        The active organization
 
     """
     client = client or global_graph_client()
@@ -253,16 +253,9 @@ def active_org(org: Union[str, Org], client: Optional[GraphClient] = None):
     On exit, the user's active organization is restored.
 
     Args:
-        org: an org ID or Org
+        org: an organization ID or Org
         client: If specified, this client is used to fetch metadata from the
             API. Otherwise, the global GraphClient is used.
-
-    Returns:
-
-    Examples:
-        with active_org("abc124") as new_org:
-            print('The current org is', new_org.name)
-            # do something
 
     """
     current_user = get_current_user(client)

--- a/runeq/resources/org.py
+++ b/runeq/resources/org.py
@@ -222,9 +222,9 @@ def set_active_org(
             user {
                 defaultMembership {
                     org {
-                                id
-                                created_at: created
-                                name: displayName
+                        id
+                        created_at: created
+                        name: displayName
                     }
                 }
             }

--- a/runeq/resources/org.py
+++ b/runeq/resources/org.py
@@ -232,7 +232,7 @@ def set_active_org(
     }
     '''
 
-    result = client.execute(statement=statement, id=org_id)
+    result = client.execute(statement=statement, input={"orgId": org_id})
 
     user_attrs = result.get("updateDefaultMembership", {}).get("user", {})
     org_attrs = user_attrs.get("defaultMembership", {}).get("org")

--- a/tests/resources/test_org.py
+++ b/tests/resources/test_org.py
@@ -350,7 +350,10 @@ class TestOrg(TestCase):
         # Test that active org is switched when the context manager
         # is active, and then restored on exit
         with active_org(org2_id, self.mock_client) as new_org:
-            mock_set_active_org.assert_called_once_with(org2_id, self.mock_client)
+            mock_set_active_org.assert_called_once_with(
+                org2_id,
+                self.mock_client
+            )
             self.assertEqual(new_org.id, org2_id)
 
             mock_set_active_org.reset_mock()
@@ -362,7 +365,10 @@ class TestOrg(TestCase):
         # Active org is restored even if an exception is raised
         with self.assertRaises(ValueError):
             with active_org(org2_id, self.mock_client):
-                mock_set_active_org.assert_called_once_with(org2_id, self.mock_client)
+                mock_set_active_org.assert_called_once_with(
+                    org2_id,
+                    self.mock_client
+                )
                 raise ValueError()
 
         mock_set_active_org.assert_called_with(org1_id, self.mock_client)

--- a/tests/resources/test_org.py
+++ b/tests/resources/test_org.py
@@ -6,7 +6,14 @@ from unittest import TestCase, mock
 
 from runeq.config import Config
 from runeq.resources.client import GraphClient
-from runeq.resources.org import Org, get_org, get_orgs
+from runeq.resources.org import (
+    active_org,
+    get_org,
+    get_orgs,
+    Org,
+    set_active_org
+)
+from runeq.resources.user import User
 
 
 class TestOrg(TestCase):
@@ -112,24 +119,48 @@ class TestOrg(TestCase):
         Test get org for specified org_id.
 
         """
-        self.mock_client.execute = mock.Mock()
-        self.mock_client.execute.side_effect = [
-            {
-                "org": {
-                    "id": "org1-id",
-                    "created_at": 1630515986.9949625,
-                    "name": "org1"
+        self.mock_client.execute = mock.Mock(return_value={
+            "user": {
+                "membershipList": {
+                    "pageInfo": {
+                        "endCursor": None
+                    },
+                    "memberships": [
+                        {
+                            "org": {
+                                "id": "org1-id",
+                                "created_at": 1571267538.391721,
+                                "name": "org1"
+                            }
+                        },
+                        {
+                            "org": {
+                                "id": "org2-id",
+                                "created_at": 1630515986.9949625,
+                                "name": "org2"
+                            }
+                        }
+                    ]
                 }
             }
-        ]
+        })
 
         org = get_org("org1-id", client=self.mock_client)
-
         self.assertEqual(
             {
                 "id": "org1-id",
-                "created_at": 1630515986.9949625,
+                "created_at": 1571267538.391721,
                 "name": "org1"
+            },
+            org.to_dict(),
+        )
+
+        org = get_org("org2-id", client=self.mock_client)
+        self.assertEqual(
+            {
+                "id": "org2-id",
+                "created_at": 1630515986.9949625,
+                "name": "org2"
             },
             org.to_dict(),
         )
@@ -262,3 +293,76 @@ class TestOrg(TestCase):
             orgs.to_list(),
         )
 
+    def test_set_active_org(self):
+
+        org_id = "org1-id"
+        self.mock_client.execute = mock.Mock()
+        self.mock_client.execute.side_effect = [
+            {
+                "updateDefaultMembership": {
+                    "user": {
+                        "defaultMembership": {
+                            "org": {
+                                "id": org_id,
+                                "name": "org1",
+                                "created_at": 1571267538.391721,
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+
+        new_org = set_active_org(org_id, self.mock_client)
+        self.mock_client.execute.assert_called_once()
+        self.assertEqual(
+            new_org.to_dict(),
+            {
+                'created_at': 1571267538.391721,
+                'name': 'org1',
+                'id': 'org1-id'
+            }
+        )
+
+    @mock.patch('runeq.resources.org.get_current_user')
+    @mock.patch('runeq.resources.org.set_active_org')
+    def test_with_active_org(self, mock_set_active_org, mock_get_current_user):
+        """
+        Test active org context manager.
+
+        """
+        org1_id = "org1-id"
+        org2_id = "org2-id"
+
+        mock_get_current_user.return_value = User(
+            id="user1-id",
+            created_at=1629300943.9179766,
+            name="User 1",
+            active_org_id=org1_id,
+            active_org_name="Org 1",
+        )
+        mock_set_active_org.return_value = Org(
+            id=org2_id,
+            created_at=1629300943.9179766,
+            name="org2",
+        )
+
+        # Test that active org is switched when the context manager
+        # is active, and then restored on exit
+        with active_org(org2_id, self.mock_client) as new_org:
+            mock_set_active_org.assert_called_once_with(org2_id, self.mock_client)
+            self.assertEqual(new_org.id, org2_id)
+
+            mock_set_active_org.reset_mock()
+
+        mock_set_active_org.assert_called_with(org1_id, self.mock_client)
+
+        mock_set_active_org.reset_mock()
+
+        # Active org is restored even if an exception is raised
+        with self.assertRaises(ValueError):
+            with active_org(org2_id, self.mock_client):
+                mock_set_active_org.assert_called_once_with(org2_id, self.mock_client)
+                raise ValueError()
+
+        mock_set_active_org.assert_called_with(org1_id, self.mock_client)


### PR DESCRIPTION
* Adding a function that allows the user to set their active org, using either an org ID or `Org` object (`set_active_org`)
* Adding a context manager wrapper (`active_org`), which sets the active org for the block of code (and set it back on exit)
* Updating `get_org` so that it can fetch metadata about any org the user belongs to. It's hacky because of how the underlying mutation does access control.... but it'll work 🤷‍♀️ 

The documentation changes were more difficult than the code changes 😅 LMK if the docs make sense or if you have any suggestions.