### PR TITLE
Add to_dataframe to ItemSet; support datetime.datetime

### DIFF
--- a/runeq/resources/common.py
+++ b/runeq/resources/common.py
@@ -6,6 +6,8 @@ from abc import ABC, abstractmethod
 from collections import OrderedDict
 from typing import Any, Dict, Iterable, Iterator, List, Type, Union
 
+import pandas as pd
+
 
 class ItemBase:
     """
@@ -226,3 +228,7 @@ class ItemSet(ABC):
             items_list.append(item.to_dict())
 
         return items_list
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Convert items to a dataframe (wraps `to_list()`)"""
+        return pd.DataFrame(self.to_list())

--- a/runeq/resources/stream.py
+++ b/runeq/resources/stream.py
@@ -114,8 +114,8 @@ def get_stream_data(
 
 def get_stream_availability(
     stream_ids: Union[str, Iterable[str]],
-    start_time: Union[float, datetime.date],
-    end_time: Union[float, datetime.date],
+    start_time: _time_type,
+    end_time: _time_type,
     resolution: int,
     batch_operation: Optional[str] = None,
     format: Optional[str] = 'csv',
@@ -135,9 +135,9 @@ def get_stream_availability(
         stream_ids: 1 or multiple stream IDs. If multiple stream IDs are
             specified, **batch_operation** is also required.
         start_time: Start time for the query, provided as a unix timestamp
-            (in seconds) or a datetime.date.
+            (in seconds), a datetime.datetime, or a datetime.date.
         end_time: End time for the query, provided as a unix timestamp
-            (in seconds) or a datetime.date.
+            (in seconds), a datetime.datetime, or a datetime.date.
         resolution: Interval between returned timestamps, in seconds.
         batch_operation: Either "any" or "all", which determines
             what type of batch calculation will determine availability for
@@ -178,8 +178,8 @@ def get_stream_availability(
 
     """
     params = {
-        'start_time': start_time,
-        'end_time': end_time,
+        'start_time': _time_type_to_unix_secs(start_time),
+        'end_time': _time_type_to_unix_secs(end_time),
         'resolution': resolution,
         'batch_operation': batch_operation,
         'format': format,
@@ -189,11 +189,6 @@ def get_stream_availability(
         'timezone': timezone,
         'timezone_name': timezone_name,
     }
-
-    if type(start_time) is datetime.date:
-        params['start_time'] = time.mktime(start_time.timetuple())
-    if type(end_time) is datetime.date:
-        params['end_time'] = time.mktime(end_time.timetuple())
 
     client = client or global_stream_client()
 

--- a/runeq/resources/stream.py
+++ b/runeq/resources/stream.py
@@ -12,7 +12,7 @@ from .client import StreamClient, global_stream_client
 _time_type = Union[int, float, date, datetime]
 
 
-def _time_type_to_unix_secs(t: _time_type):
+def _time_type_to_unix_secs(t: _time_type) -> Union[int, float]:
     """Standardize time input as timestamp (in unix secs)"""
     if isinstance(t, datetime):
         return t.timestamp()

--- a/runeq/resources/stream_metadata.py
+++ b/runeq/resources/stream_metadata.py
@@ -12,7 +12,7 @@ import pandas as pd
 from .client import GraphClient, StreamClient, global_graph_client
 from .common import ItemBase, ItemSet
 from .patient import Device, Patient, get_patient
-from .stream import get_stream_availability, get_stream_data
+from .stream import get_stream_availability, get_stream_data, _time_type
 from runeq.errors import RuneError
 
 
@@ -268,9 +268,9 @@ class StreamMetadata(ItemBase):
 
     def iter_stream_data(
         self,
-        start_time: Optional[Union[float, datetime.date]] = None,
+        start_time: Optional[_time_type] = None,
         start_time_ns: Optional[int] = None,
-        end_time: Optional[Union[float, datetime.date]] = None,
+        end_time: Optional[_time_type] = None,
         end_time_ns: Optional[int] = None,
         format: Optional[str] = "csv",
         limit: Optional[int] = None,
@@ -285,11 +285,11 @@ class StreamMetadata(ItemBase):
 
         Args:
             start_time: Start time for the query, provided as a unix timestamp
-                (in seconds) or a datetime.date.
+                (in seconds), a datetime.datetime, or a datetime.date.
             start_time_ns: Start time for the query, provided as a unix
                 timestamp (in nanoseconds).
             end_time: End time for the query, provided as a unix timestamp
-                (in seconds) or a datetime.date.
+                (in seconds), a datetime.datetime, or a datetime.date.
             end_time_ns: End time for the query, provided as a unix timestamp
                 (in nanoseconds).
             format: Either "csv" (default) or "json". Determines the content

--- a/tests/resources/test_stream.py
+++ b/tests/resources/test_stream.py
@@ -95,7 +95,7 @@ class TestStreamData(TestCase):
             translate_enums=False,
             client=self.stream_client,
         )
-        # consume the iterator
+        # call list() to consume the iterator
         _ = list(data)
 
         expected_headers = {
@@ -130,6 +130,7 @@ class TestStreamData(TestCase):
             end_time=datetime(2023, 8, 11, 10, 26, 45, 1, tzinfo=timezone.utc),
             client=self.stream_client,
         )
+        # call list() to consume the iterator
         _ = list(data)
 
         mock_requests.get.assert_called_once_with(


### PR DESCRIPTION
Two minor improvements:
* Adding a convenience method to the `ItemSet` class, to create a pandas dataframe representing the items in the set
* Adding support for `datetime.datetime` as an input for `get_stream_data` and `get_stream_availability`. These functions currently accept `datetime.date`, which only has precision to the day.