### PR TITLE
Dependency upgrades (click, python 3.11 and 3.12)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ workflows:
             - lint:
                 matrix:
                     parameters:
-                        executor: ["python3_11"]
+                        executor: ["python3_12"]
             - test:
                 matrix:
                     parameters:
@@ -109,8 +109,8 @@ workflows:
             - docs:
                 matrix:
                     parameters:
-                        executor: ["python3_11"]
+                        executor: ["python3_12"]
             - build-pypi:
                 matrix:
                     parameters:
-                        executor: ["python3_11"]
+                        executor: ["python3_12"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,10 @@ executors:
         docker:
             - image: cimg/python:3.11
 
+    python3_12:
+        docker:
+            - image: cimg/python:3.12
+
 jobs:
     lint:
         parameters:
@@ -101,7 +105,7 @@ workflows:
             - test:
                 matrix:
                     parameters:
-                        executor: ["python3_6", "python3_7", "python3_8", "python3_9", "python3_10", "python3_11"]
+                        executor: ["python3_6", "python3_7", "python3_8", "python3_9", "python3_10", "python3_11", "python3_12"]
             - docs:
                 matrix:
                     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,10 @@ executors:
         docker:
             - image: cimg/python:3.10
 
+    python3_11:
+        docker:
+            - image: cimg/python:3.11
+
 jobs:
     lint:
         parameters:
@@ -93,16 +97,16 @@ workflows:
             - lint:
                 matrix:
                     parameters:
-                        executor: ["python3_10"]
+                        executor: ["python3_11"]
             - test:
                 matrix:
                     parameters:
-                        executor: ["python3_6", "python3_7", "python3_8", "python3_9", "python3_10"]
+                        executor: ["python3_6", "python3_7", "python3_8", "python3_9", "python3_10", "python3_11"]
             - docs:
                 matrix:
                     parameters:
-                        executor: ["python3_10"]
+                        executor: ["python3_11"]
             - build-pypi:
                 matrix:
                     parameters:
-                        executor: ["python3_10"]
+                        executor: ["python3_11"]

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
     configuration: docs/conf.py
@@ -14,6 +19,5 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
   install:
     - requirements: requirements/docs.txt

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,5 +1,5 @@
 boto3>=1.23.0
-click~=7.1
+click>=7.1
 gql~=2.0.0
 numpy>=1.18.2
 PyYAML>=5.3.1

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('requirements/common.txt', 'r') as r:
 
 setup(
     name=package_name,
-    version='0.13.0',
+    version='0.13.1',
     author='Rune Labs',
     maintainer_email='support@runelabs.io',
     description='Query data from Rune Labs APIs',


### PR DESCRIPTION
* Upgrading Click with a wider dependency range. No breaking changes after 7.0: https://click.palletsprojects.com/en/8.1.x/upgrading/
* Adding a newly required option to readthedocs config: https://blog.readthedocs.com/use-build-os-config/
* Testing against newer Python releases