### PR TITLE
Update repo links

### DIFF
--- a/examples/01_getting_started_with_Rune_SDK.ipynb
+++ b/examples/01_getting_started_with_Rune_SDK.ipynb
@@ -23,7 +23,7 @@
     "For detailed information:\n",
     "* [Rune Labs API documentation](https://docs.runelabs.io/stream/v2/)\n",
     "* [Rune Labs SDK documentation](https://runeq.readthedocs.io/en/latest/)\n",
-    "* [Rune Labs open source code respository](https://github.com/rune-labs/opensource) (which includes this notebook)"
+    "* [Rune Labs open source code respository](https://github.com/rune-labs/runeq-python/tree/main/examples) (which includes this notebook)"
    ]
   },
   {

--- a/examples/02_exploring_organizations_and_patients.ipynb
+++ b/examples/02_exploring_organizations_and_patients.ipynb
@@ -16,7 +16,7 @@
     "For detailed information:\n",
     "* [Rune Labs API documentation](https://docs.runelabs.io/stream/v2/)\n",
     "* [Rune Labs SDK documentation](https://runeq.readthedocs.io/en/latest/)\n",
-    "* [Rune Labs open source code respository](https://github.com/rune-labs/opensource) (which includes this notebook)"
+    "* [Rune Labs open source code respository](https://github.com/rune-labs/runeq-python/tree/main/examples) (which includes this notebook)"
    ]
   },
   {

--- a/examples/03_exploring_patient_devices.ipynb
+++ b/examples/03_exploring_patient_devices.ipynb
@@ -16,7 +16,7 @@
     "For detailed information:\n",
     "* [Rune Labs API documentation](https://docs.runelabs.io/stream/v2/)\n",
     "* [Rune Labs SDK documentation](https://runeq.readthedocs.io/en/latest/)\n",
-    "* [Rune Labs open source code respository](https://github.com/rune-labs/opensource) (which includes this notebook)"
+    "* [Rune Labs open source code respository](https://github.com/rune-labs/runeq-python/tree/main/examples) (which includes this notebook)"
    ]
   },
   {

--- a/examples/04_querying_stream_metadata.ipynb
+++ b/examples/04_querying_stream_metadata.ipynb
@@ -16,7 +16,7 @@
     "For detailed information:\n",
     "* [Rune Labs API documentation](https://docs.runelabs.io/stream/v2/)\n",
     "* [Rune Labs SDK documentation](https://runeq.readthedocs.io/en/latest/)\n",
-    "* [Rune Labs open source code respository](https://github.com/rune-labs/opensource) (which includes this notebook)"
+    "* [Rune Labs open source code respository](https://github.com/rune-labs/runeq-python/tree/main/examples) (which includes this notebook)"
    ]
   },
   {
@@ -413,7 +413,7 @@
     "* `device_id` – Device ID of the data source device\n",
     "    * discussed in [Exploring Patient Devices with the Rune Labs API/SDK](03_exploring_patient_devices.ipynb)\n",
     "* `stream_type_id` – Stream type ID\n",
-    "    * discussed in **TODO: link to stream types notebook**\n",
+    "    * discussed in [Understanding Types of Data Streams Used by the Rune Labs API/SDK](06_stream_types.ipynb)\n",
     "* `algorithm` – A versioned label that describes the process that was used to derive the data stream\n",
     "    * typically one per data source, e.g., Apple Health, Medtronic Percept DBS\n",
     "* `category` – A broad categorization of the data type (e.g. neural, vitals, etc)\n",

--- a/examples/05_pulling_stream_data.ipynb
+++ b/examples/05_pulling_stream_data.ipynb
@@ -16,7 +16,7 @@
     "For detailed information:\n",
     "* [Rune Labs API documentation](https://docs.runelabs.io/stream/v2/)\n",
     "* [Rune Labs SDK documentation](https://runeq.readthedocs.io/en/latest/)\n",
-    "* [Rune Labs open source code respository](https://github.com/rune-labs/opensource) (which includes this notebook)"
+    "* [Rune Labs open source code respository](https://github.com/rune-labs/runeq-python/tree/main/examples) (which includes this notebook)"
    ]
   },
   {

--- a/examples/06_stream_types.ipynb
+++ b/examples/06_stream_types.ipynb
@@ -16,7 +16,7 @@
     "For detailed information:\n",
     "* [Rune Labs API documentation](https://docs.runelabs.io/stream/v2/)\n",
     "* [Rune Labs SDK documentation](https://runeq.readthedocs.io/en/latest/)\n",
-    "* [Rune Labs open source code respository](https://github.com/rune-labs/opensource) (which includes this notebook)"
+    "* [Rune Labs open source code respository](https://github.com/rune-labs/runeq-python/tree/main/examples) (which includes this notebook)"
    ]
   },
   {

--- a/examples/07_checking_data_availability.ipynb
+++ b/examples/07_checking_data_availability.ipynb
@@ -16,7 +16,7 @@
     "For detailed information:\n",
     "* [Rune Labs API documentation](https://docs.runelabs.io/stream/v2/)\n",
     "* [Rune Labs SDK documentation](https://runeq.readthedocs.io/en/latest/)\n",
-    "* [Rune Labs open source code respository](https://github.com/rune-labs/opensource) (which includes this notebook)"
+    "* [Rune Labs open source code respository](https://github.com/rune-labs/runeq-python/tree/main/examples) (which includes this notebook)"
    ]
   },
   {

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,7 +14,7 @@ The Rune Labs software development kit (SDK), called `runeq`, is a set of tools 
 For detailed information:
 * [Rune Labs API documentation](https://docs.runelabs.io/stream/v2/)
 * [Rune Labs SDK documentation](https://runeq.readthedocs.io/en/latest/)
-* [Rune Labs open source code respository](https://github.com/rune-labs/opensource)
+* [Rune Labs open source code respository](https://github.com/rune-labs/runeq-python/tree/main/examples)
 
 ---
 


### PR DESCRIPTION
Each notebook links back to the base repo. These links needed to be updated because we moved from the opensource to the runeq-python repo.