### PR TITLE
Add ability to initialize library with a config

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -114,7 +114,7 @@ def setup(access_token_id, access_token_secret):
 
 @configure.command()
 @click.option(
-    "--key", "-k", default="", multiple=True, required=False, help="1+ keys to fetch"
+    "--key", "-k", default=[], multiple=True, required=False, help="1+ keys to fetch"
 )
 def get(key):
     """

--- a/runeq/config.py
+++ b/runeq/config.py
@@ -2,6 +2,7 @@
 Configuration for accessing Rune APIs.
 
 """
+
 import os
 
 import boto3
@@ -38,9 +39,39 @@ Default path for the config file (yaml formatted)
 """
 
 
-class Config:
+class BaseConfig:
+    """Base class to hold configuration for accessing Rune APIs."""
+
+    graph_url: str
+    stream_url: str
+
+    def refresh_auth(self) -> bool:
+        """
+        Refresh authentication credentials if possible, returning a bool
+        indicating if the refresh occurred.
+
+        This is specific to the authentication style: e.g. it may
+        be implemented to refresh a JWT. By default, it is a no-op.
+
+        The API clients contain logic to catch possible authentication
+        errors, invoke this method, and retry the request (if credentials
+        are successfully refreshed).
+
+        """
+        return False
+
+    @property
+    def auth_headers(self) -> dict:
+        """
+        Authentication headers for HTTP requests to Rune APIs.
+
+        """
+        raise NotImplementedError("auth_headers must be implemented by a subclass")
+
+
+class Config(BaseConfig):
     """
-    Holds configuration (e.g. auth credentials, URLs, etc)
+    Holds configuration for Rune API usage (e.g. auth credentials, URLs, etc)
 
     """
 

--- a/runeq/resources/client.py
+++ b/runeq/resources/client.py
@@ -2,6 +2,8 @@
 Clients for Rune's GraphQL API and V2 Stream API.
 
 """
+
+from functools import wraps
 import time
 import urllib.parse
 from functools import wraps
@@ -12,6 +14,7 @@ from gql import Client as GQLClient
 from gql import gql
 from gql.transport.requests import RequestsHTTPTransport
 
+from runeq.config import BaseConfig, Config
 from runeq import errors
 from runeq.config import Config
 
@@ -66,12 +69,12 @@ class GraphClient:
     """
 
     # Configuration details for the graph client.
-    config: Config = None
+    config: BaseConfig = None
 
     # The GraphQL client.
     _gql_client: GQLClient
 
-    def __init__(self, config: Config):
+    def __init__(self, config: BaseConfig):
         """
         Initialize the Graph API Client.
 
@@ -131,9 +134,9 @@ class StreamClient:
     HEADER_NEXT_PAGE = "X-Rune-Next-Page-Token"
 
     # Configuration details for the stream client.
-    config: Config = None
+    config: BaseConfig = None
 
-    def __init__(self, config: Config):
+    def __init__(self, config: BaseConfig):
         """
         Initialize the Stream API Client.
 
@@ -247,7 +250,14 @@ def initialize(*args, **kwargs):
 
     """
     config = Config(*args, **kwargs)
+    initialize_with_config(config)
 
+
+def initialize_with_config(config: BaseConfig):
+    """Initializes the library using a config object, setting global clients
+    for requests to the GraphQL API and the V2 Stream API.
+
+    """
     global _graph_client, _stream_client
     _graph_client = GraphClient(config)
     _stream_client = StreamClient(config)

--- a/runeq/resources/client.py
+++ b/runeq/resources/client.py
@@ -3,7 +3,6 @@ Clients for Rune's GraphQL API and V2 Stream API.
 
 """
 
-from functools import wraps
 import time
 import urllib.parse
 from functools import wraps
@@ -14,9 +13,8 @@ from gql import Client as GQLClient
 from gql import gql
 from gql.transport.requests import RequestsHTTPTransport
 
-from runeq.config import BaseConfig, Config
 from runeq import errors
-from runeq.config import Config
+from runeq.config import BaseConfig, Config
 
 # Error when a client is not initialized
 INITIALIZATION_ERROR = errors.InitializationError(

--- a/runeq/stream/v1.py
+++ b/runeq/stream/v1.py
@@ -2,6 +2,7 @@
 Query data from the Rune Labs Stream API (V1).
 
 """
+
 import csv
 from logging import getLogger
 from typing import Iterator, Union
@@ -71,7 +72,7 @@ class StreamV1Base:
     # Not supported for all resources.
     _availability = None
 
-    def __init__(self, cfg: config.Config, **defaults):
+    def __init__(self, cfg: config.BaseConfig, **defaults):
         """
         Initialize with a Config and default query parameters.
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("requirements/common.txt", "r") as r:
 
 setup(
     name=package_name,
-    version="0.13.1",
+    version="0.14.0",
     author="Rune Labs",
     maintainer_email="support@runelabs.io",
     description="Query data from Rune Labs APIs",

--- a/tests/resources/test_client.py
+++ b/tests/resources/test_client.py
@@ -3,17 +3,17 @@ Tests for the V2 SDK Client.
 
 """
 
-from unittest import mock, TestCase
+from unittest import TestCase, mock
 
 from runeq import errors
 from runeq.config import BaseConfig
 from runeq.resources.client import (
-    initialize,
-    initialize_with_config,
-    global_graph_client,
-    global_stream_client,
     GraphClient,
     StreamClient,
+    global_graph_client,
+    global_stream_client,
+    initialize,
+    initialize_with_config,
 )
 from runeq.resources.stream import get_stream_data
 

--- a/tests/resources/test_client.py
+++ b/tests/resources/test_client.py
@@ -2,10 +2,19 @@
 Tests for the V2 SDK Client.
 
 """
-from unittest import TestCase, mock
+
+from unittest import mock, TestCase
 
 from runeq import errors
-from runeq.resources.client import GraphClient, StreamClient, initialize
+from runeq.config import BaseConfig
+from runeq.resources.client import (
+    initialize,
+    initialize_with_config,
+    global_graph_client,
+    global_stream_client,
+    GraphClient,
+    StreamClient,
+)
 from runeq.resources.stream import get_stream_data
 
 
@@ -49,6 +58,24 @@ class TestInitialize(TestCase):
         with self.assertRaisesRegex(errors.APIError, "401 InvalidAuthentication"):
             get_stream_data("stream_id").__next__()
 
+    def test_initialize_with_config(self):
+        """
+        Test initializing with a config object.
+
+        """
+        config = mock.Mock(spec=BaseConfig)
+        config.graph_url = "graph-url"
+        config.stream_url = "stream-url"
+        config.auth_headers = {"hello": "world"}
+
+        initialize_with_config(config)
+
+        graph_client = global_graph_client()
+        stream_client = global_stream_client()
+
+        self.assertIs(graph_client.config, config)
+        self.assertIs(stream_client.config, config)
+
 
 class TestStreamClient(TestCase):
     """
@@ -67,7 +94,7 @@ class TestStreamClient(TestCase):
     @mock.patch("runeq.resources.client.requests.get")
     def test_refresh_auth_on_4xx(self, mock_get):
         """If a request fails with a 4xx status code, refresh auth and retry"""
-        config = mock.Mock()
+        config = mock.Mock(spec=BaseConfig)
         config.stream_url = ""
         config.refresh_auth.return_value = True
 
@@ -85,7 +112,7 @@ class TestStreamClient(TestCase):
     @mock.patch("runeq.resources.client.requests.get")
     def test_no_retry_on_5xx(self, mock_get):
         """If a request fails with a 5xx status code, do not retry"""
-        config = mock.Mock()
+        config = mock.Mock(spec=BaseConfig)
         config.stream_url = ""
         config.refresh_auth.return_value = True
 
@@ -110,7 +137,7 @@ class TestGraphClient(TestCase):
     @mock.patch("runeq.resources.client.GQLClient")
     def test_refresh_auth_on_error(self, mock_client_cls):
         """If a request fails with any error, refresh auth and retry"""
-        config = mock.Mock()
+        config = mock.Mock(spec=BaseConfig)
         config.graph_url = ""
         config.auth_headers = {"hello": "world"}
 


### PR DESCRIPTION
The key changes are:
* A `BaseConfig` class that defines the core functionality of the `Config` class. This is now used for typehinting.
* `initialize_with_config` allows you to initialize the library with an existing config instance.
* Bumping the version from 0.13.1 -> 0.14.0

This PR also includes a small fix for the CLI (a default value was invalid; I'm assuming a later version of Click got stricter about this).