### PR TITLE
Add black and isort autoformatting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,9 +9,13 @@ ignore =
     E126
     E201
     E202
+    # Flake8 is not PEP-8 compliant for slice syntax, but black is.
+    E203
     E303
     E305
     E402
+    # Ignore line length limits as these are handled by black.
+    E501
     W391
     W503
     W504

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+profile = black

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,30 @@ init: $(VENV_NAME)
 	. $(VENV_ACTIVATE) && pip install -r requirements/dev.txt
 
 .PHONY: lint
-lint:
+lint: black-check isort-check flake8
+
+.PHONY: flake8
+flake8:
 	. $(VENV_ACTIVATE) && flake8 .
+
+.PHONY: black-check
+black-check:
+	. $(VENV_ACTIVATE) && black --check .
+
+.PHONY: black-format
+black-format:
+	. $(VENV_ACTIVATE) && black .
+
+.PHONY: isort-check
+isort-check:
+	. $(VENV_ACTIVATE) && isort --check .
+
+.PHONY: isort-format
+isort-format:
+	. $(VENV_ACTIVATE) && isort .
+
+.PHONY: format
+format: black-format isort-format ## format code and sort imports
 
 .PHONY: test
 test:

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -4,9 +4,9 @@ runeq command line interface
 
 """
 import os
-import yaml
 
 import click
+import yaml
 
 from runeq.config import DEFAULT_CONFIG_YAML
 
@@ -23,7 +23,7 @@ def _write_config(values):
     if not os.path.isdir(dirpath):
         os.mkdir(dirpath)
 
-    with open(filepath, 'w') as f:
+    with open(filepath, "w") as f:
         yaml.dump(values, f)
 
 
@@ -50,10 +50,10 @@ def _get_config() -> dict:
     # If the contents of the config file are not a dictionary, ask the user
     # if they want to overwrite the contents.
     prompt = (
-        'Detected invalid contents in the config file ({})\nWould you like to '
-        'reset the contents?'.format(filepath)
+        "Detected invalid contents in the config file ({})\nWould you like to "
+        "reset the contents?".format(filepath)
     )
-    if not click.confirm(click.style(prompt, fg='red')):
+    if not click.confirm(click.style(prompt, fg="red")):
         raise click.Abort()
 
     _write_config({})
@@ -77,37 +77,45 @@ def configure():
 
 
 @configure.command()
-@click.option('--access-token-id', required=True,
-              prompt='Enter an access token ID',
-              help='Rune access token ID')
-@click.option('--access-token-secret', required=True,
-              prompt='Enter an access token secret',
-              help='Rune access token secret')
+@click.option(
+    "--access-token-id",
+    required=True,
+    prompt="Enter an access token ID",
+    help="Rune access token ID",
+)
+@click.option(
+    "--access-token-secret",
+    required=True,
+    prompt="Enter an access token secret",
+    help="Rune access token secret",
+)
 def setup(access_token_id, access_token_secret):
     """
     Set up a runeq configuration file. This will overwrite any existing values.
 
     """
     if _get_config():
-        prompt = (
-            'Found existing config values. Would you like to overwrite them?'
-        )
-        if not click.confirm(click.style(prompt, fg='red')):
+        prompt = "Found existing config values. Would you like to overwrite them?"
+        if not click.confirm(click.style(prompt, fg="red")):
             raise click.Abort()
 
-    _write_config({
-        'access_token_id': access_token_id,
-        'access_token_secret': access_token_secret,
-    })
-    click.echo(click.style(
-        f'Success! Created a configuration file: {DEFAULT_CONFIG_YAML}',
-        fg='green'
-    ))
+    _write_config(
+        {
+            "access_token_id": access_token_id,
+            "access_token_secret": access_token_secret,
+        }
+    )
+    click.echo(
+        click.style(
+            f"Success! Created a configuration file: {DEFAULT_CONFIG_YAML}", fg="green"
+        )
+    )
 
 
 @configure.command()
-@click.option('--key', '-k', default='', multiple=True, required=False,
-              help='1+ keys to fetch')
+@click.option(
+    "--key", "-k", default="", multiple=True, required=False, help="1+ keys to fetch"
+)
 def get(key):
     """
     Print one or more values from the current runeq configuration. If no keys
@@ -118,16 +126,21 @@ def get(key):
 
     if not key:
         for k in sorted(config):
-            print('{}: {}'.format(k, config[k]))
+            print("{}: {}".format(k, config[k]))
     else:
         for k in key:
-            print('{}: {}'.format(k, config.get(k, '')))
+            print("{}: {}".format(k, config.get(k, "")))
 
 
 @configure.command()
-@click.option('--value', '-v', multiple=True, required=True,
-              help='1+ values to set in the config file. Each option should'
-                   'be provided as [key]=[value]')
+@click.option(
+    "--value",
+    "-v",
+    multiple=True,
+    required=True,
+    help="1+ values to set in the config file. Each option should"
+    "be provided as [key]=[value]",
+)
 def set(value):
     """
     Set a value in the runeq configuration file.
@@ -136,11 +149,9 @@ def set(value):
     config = _get_config()
 
     for item in value:
-        elements = item.split('=')
+        elements = item.split("=")
         if len(elements) != 2:
-            raise click.ClickException(
-                'Each option must be provided as [key]=[value]'
-            )
+            raise click.ClickException("Each option must be provided as [key]=[value]")
 
         k, v = elements
         config[k.strip()] = v.strip()
@@ -148,5 +159,5 @@ def set(value):
     _write_config(config)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     cli()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,14 +12,15 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../'))
+
+sys.path.insert(0, os.path.abspath("../"))
 
 
 # -- Project information -----------------------------------------------------
 
-project = 'runeq'
-copyright = '2020, Rune Labs'
-author = 'Rune Labs'
+project = "runeq"
+copyright = "2020, Rune Labs"
+author = "Rune Labs"
 
 
 # -- General configuration ---------------------------------------------------
@@ -28,18 +29,18 @@ author = 'Rune Labs'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
+    "sphinx.ext.autodoc",
     # support for google-style docstrings
-    'sphinx.ext.napoleon',
+    "sphinx.ext.napoleon",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -47,9 +48,9 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,10 @@
 -r common.txt
 -r docs.txt
 # used only for development and CI
+black==23.12.1
+flake8==6.1.0
+flake8-isort==6.1.1
+isort==5.13.2
 coverage
 flake8
 setuptools

--- a/runeq/__init__.py
+++ b/runeq/__init__.py
@@ -3,14 +3,13 @@ The Rune Labs Standard Development Kit (SDK) for querying data from Rune
 APIs.
 
 """
-from . import stream, resources
+from . import resources, stream
 from .config import Config
 from .resources.client import initialize
 
-
 __all__ = [
-    'Config',
-    'initialize',
-    'resources',
-    'stream',
+    "Config",
+    "initialize",
+    "resources",
+    "stream",
 ]

--- a/runeq/config.py
+++ b/runeq/config.py
@@ -3,36 +3,35 @@ Configuration for accessing Rune APIs.
 
 """
 import os
-import yaml
 
 import boto3
+import yaml
 
-
-AUTH_METHOD_CLIENT_KEYS = 'client_keys'
+AUTH_METHOD_CLIENT_KEYS = "client_keys"
 """
 Auth method to use a Client Key pair for authentication.
 
 """
 
-AUTH_METHOD_JWT = 'jwt'
+AUTH_METHOD_JWT = "jwt"
 """
 Auth method to use a JWT for authentication.
 
 """
 
-AUTH_METHOD_COGNITO_REFRESH = 'cognito_refresh'
+AUTH_METHOD_COGNITO_REFRESH = "cognito_refresh"
 """
 Auth method to use a Cognito refresh token for authentication.
 
 """
 
-AUTH_METHOD_ACCESS_TOKEN = 'access_token'
+AUTH_METHOD_ACCESS_TOKEN = "access_token"
 """
 Auth method to use a user access token for authentication.
 
 """
 
-DEFAULT_CONFIG_YAML = '~/.rune/config'
+DEFAULT_CONFIG_YAML = "~/.rune/config"
 """
 Default path for the config file (yaml formatted)
 
@@ -70,8 +69,8 @@ class Config:
             # user access token.
 
         """
-        self.graph_url = 'https://graph.runelabs.io'
-        self.stream_url = 'https://stream.runelabs.io'
+        self.graph_url = "https://graph.runelabs.io"
+        self.stream_url = "https://stream.runelabs.io"
         self.auth_method = None
 
         self._access_token_id = None
@@ -84,14 +83,15 @@ class Config:
 
         if args and kwargs:
             raise TypeError(
-                '__init__() cannot accept both positional arguments and '
-                'keyword arguments'
+                "__init__() cannot accept both positional arguments and "
+                "keyword arguments"
             )
         elif args:
             if len(args) > 1:
                 raise TypeError(
-                    '__init__() takes at most 1 positional argument but '
-                    f'{len(args)} were given')
+                    "__init__() takes at most 1 positional argument but "
+                    f"{len(args)} were given"
+                )
 
             self.load_yaml(args[0])
         elif not kwargs:
@@ -122,7 +122,7 @@ class Config:
         jwt=None,
         cognito_client_id=None,
         cognito_refresh_token=None,
-        cognito_region_name='us-west-2',
+        cognito_region_name="us-west-2",
         stream_url=None,
         graph_url=None,
         **kwargs,
@@ -152,17 +152,19 @@ class Config:
             self.graph_url = graph_url
 
         if auth_method is None:
-            num_auth_methods_set = sum([
-                bool(access_token_id or access_token_secret),
-                bool(client_access_key or client_key_id),
-                bool(jwt),
-                bool(cognito_refresh_token and cognito_client_id),
-            ])
+            num_auth_methods_set = sum(
+                [
+                    bool(access_token_id or access_token_secret),
+                    bool(client_access_key or client_key_id),
+                    bool(jwt),
+                    bool(cognito_refresh_token and cognito_client_id),
+                ]
+            )
 
             if num_auth_methods_set > 1:
                 raise ValueError(
-                    'Cannot infer auth method: multiple credentials were '
-                    'provided. Specify auth_method kwarg to disambiguate.'
+                    "Cannot infer auth method: multiple credentials were "
+                    "provided. Specify auth_method kwarg to disambiguate."
                 )
             elif access_token_id and access_token_secret:
                 auth_method = AUTH_METHOD_ACCESS_TOKEN
@@ -174,8 +176,8 @@ class Config:
                 auth_method = AUTH_METHOD_COGNITO_REFRESH
             else:
                 raise ValueError(
-                    'Cannot infer auth method: a complete set of credentials '
-                    'was not provided.'
+                    "Cannot infer auth method: a complete set of credentials "
+                    "was not provided."
                 )
 
         self.auth_method = auth_method
@@ -216,13 +218,13 @@ class Config:
 
         """
         if not self._client_access_key:
-            raise ValueError('Client access key is not set')
+            raise ValueError("Client access key is not set")
         if not self._client_key_id:
-            raise ValueError('Client key id is not set')
+            raise ValueError("Client key id is not set")
 
         return {
-            'X-Rune-Client-Key-ID': self._client_key_id,
-            'X-Rune-Client-Access-Key': self._client_access_key,
+            "X-Rune-Client-Key-ID": self._client_key_id,
+            "X-Rune-Client-Access-Key": self._client_access_key,
         }
 
     @property
@@ -233,10 +235,10 @@ class Config:
         """
         if not self._jwt:
             if not self.refresh_auth():
-                raise ValueError('JWT is not set')
+                raise ValueError("JWT is not set")
 
         return {
-            'X-Rune-User-Access-Token': self._jwt,
+            "X-Rune-User-Access-Token": self._jwt,
         }
 
     def refresh_auth(self) -> bool:
@@ -254,13 +256,13 @@ class Config:
             return False
 
         response = self._cognito_client.initiate_auth(
-            AuthFlow='REFRESH_TOKEN_AUTH',
+            AuthFlow="REFRESH_TOKEN_AUTH",
             AuthParameters={
-                'REFRESH_TOKEN': self._cognito_refresh_token,
+                "REFRESH_TOKEN": self._cognito_refresh_token,
             },
-            ClientId=self._cognito_client_id
+            ClientId=self._cognito_client_id,
         )
-        self._jwt = response['AuthenticationResult']['AccessToken']
+        self._jwt = response["AuthenticationResult"]["AccessToken"]
         return True
 
     @property
@@ -270,14 +272,14 @@ class Config:
 
         """
         if not self._access_token_id:
-            raise ValueError('Access token id is not set')
+            raise ValueError("Access token id is not set")
 
         if not self._access_token_secret:
-            raise ValueError('Access token secret is not set')
+            raise ValueError("Access token secret is not set")
 
         return {
-            'X-Rune-User-Access-Token-Id': self._access_token_id,
-            'X-Rune-User-Access-Token-Secret': self._access_token_secret
+            "X-Rune-User-Access-Token-Id": self._access_token_id,
+            "X-Rune-User-Access-Token-Secret": self._access_token_secret,
         }
 
     @property
@@ -297,8 +299,8 @@ class Config:
         else:
             raise ValueError(
                 f'Invalid auth_method "{self.auth_method}": expected one of '
-                f'({AUTH_METHOD_ACCESS_TOKEN}, '
-                f'{AUTH_METHOD_CLIENT_KEYS}, '
-                f'{AUTH_METHOD_JWT}, '
-                f'{AUTH_METHOD_COGNITO_REFRESH})'
+                f"({AUTH_METHOD_ACCESS_TOKEN}, "
+                f"{AUTH_METHOD_CLIENT_KEYS}, "
+                f"{AUTH_METHOD_JWT}, "
+                f"{AUTH_METHOD_COGNITO_REFRESH})"
             )

--- a/runeq/errors.py
+++ b/runeq/errors.py
@@ -32,8 +32,8 @@ class APIError(RuneError):
         self.status_code = status_code
         self.details = details
 
-        err_type = 'Error'
-        if isinstance(details, dict) and 'type' in details:
-            err_type = details['type']
+        err_type = "Error"
+        if isinstance(details, dict) and "type" in details:
+            err_type = details["type"]
 
-        super().__init__(f'{status_code} {err_type}: {details}')
+        super().__init__(f"{status_code} {err_type}: {details}")

--- a/runeq/resources/__init__.py
+++ b/runeq/resources/__init__.py
@@ -13,14 +13,6 @@ from the `V2 Stream API <https://docs.runelabs.io/stream/v2/index.html>`_,
 using a :class:`~runeq.resources.client.StreamClient`.
 
 """
-from . import client, common, org, patient, stream_metadata, stream, user
+from . import client, common, org, patient, stream, stream_metadata, user
 
-__all__ = [
-    'client',
-    'common',
-    'org',
-    'patient',
-    'stream_metadata',
-    'stream',
-    'user'
-]
+__all__ = ["client", "common", "org", "patient", "stream_metadata", "stream", "user"]

--- a/runeq/resources/client.py
+++ b/runeq/resources/client.py
@@ -2,23 +2,23 @@
 Clients for Rune's GraphQL API and V2 Stream API.
 
 """
-from functools import wraps
 import time
-from typing import Dict, Iterator, Union
 import urllib.parse
+from functools import wraps
+from typing import Dict, Iterator, Union
 
+import requests
 from gql import Client as GQLClient
 from gql import gql
 from gql.transport.requests import RequestsHTTPTransport
-import requests
 
-from runeq.config import Config
 from runeq import errors
+from runeq.config import Config
 
 # Error when a client is not initialized
 INITIALIZATION_ERROR = errors.InitializationError(
-    'runeq must be initialized by calling'
-    '`initialize` before this function can be used'
+    "runeq must be initialized by calling"
+    "`initialize` before this function can be used"
 )
 
 # Rune GraphQL Client to query stream metadata.
@@ -48,7 +48,7 @@ def _retry(exceptions, max_attempts=3, max_sleep_secs=0):
                     if attempt == max_attempts - 1:
                         raise
 
-                wait_secs = 2 ** attempt
+                wait_secs = 2**attempt
                 if max_sleep_secs > 0:
                     wait_secs = min(wait_secs, max_sleep_secs)
 
@@ -90,10 +90,7 @@ class GraphClient:
             retries=3,
             url=f"{self.config.graph_url}/graphql",
             use_json=True,
-            headers={
-                "Content-Type": "application/json",
-                **self.config.auth_headers
-            },
+            headers={"Content-Type": "application/json", **self.config.auth_headers},
         )
         self._gql_client = GQLClient(transport=transport)
 
@@ -191,11 +188,7 @@ class StreamClient:
         again (if refresh was successful).
         """
         for i in range(2):
-            r = requests.get(
-                url,
-                headers=self.config.auth_headers,
-                params=params
-            )
+            r = requests.get(url, headers=self.config.auth_headers, params=params)
 
             if r.ok:
                 return r

--- a/runeq/resources/common.py
+++ b/runeq/resources/common.py
@@ -14,6 +14,7 @@ class ItemBase:
     Base class for representing an item.
 
     """
+
     # ID of the Item
     _id: str
 
@@ -67,10 +68,7 @@ class ItemBase:
 
         """
         if hasattr(self, "name"):
-            return (
-                f'{self.__class__.__name__}'
-                f'(id="{self.id}", name="{self.name}")'
-            )
+            return f"{self.__class__.__name__}" f'(id="{self.id}", name="{self.name}")'
         else:
             return f'{self.__class__.__name__}(id="{self.id}")'
 
@@ -156,8 +154,7 @@ class ItemSet(ABC):
         """
         if type(item) is not self._item_class:
             raise TypeError(
-                f'cannot add {str(item)}; must be type '
-                f'{self._item_class.__name__}'
+                f"cannot add {str(item)}; must be type " f"{self._item_class.__name__}"
             )
 
         self._items[item.id] = item
@@ -171,8 +168,8 @@ class ItemSet(ABC):
         for item in items:
             if type(item) is not self._item_class:
                 raise TypeError(
-                    f'cannot update with {str(item)}; all items must be type '
-                    f'{self._item_class.__name__}'
+                    f"cannot update with {str(item)}; all items must be type "
+                    f"{self._item_class.__name__}"
                 )
 
             self._items[item.id] = item
@@ -207,15 +204,13 @@ class ItemSet(ABC):
         item_strs = []
         for i, item in enumerate(self):
             if i > 2:
-                item_strs.append(
-                    f'\t... (and {len(self._items.keys()) - 3} others)\n'
-                )
+                item_strs.append(f"\t... (and {len(self._items.keys()) - 3} others)\n")
                 break
 
-            item_strs.append(f'\t{str(item)}\n')
+            item_strs.append(f"\t{str(item)}\n")
 
-        items_str = ''.join(item_strs)
-        return f'{type(self).__name__} {{\n{items_str}}}'
+        items_str = "".join(item_strs)
+        return f"{type(self).__name__} {{\n{items_str}}}"
 
     def to_list(self) -> List[dict]:
         """

--- a/runeq/resources/org.py
+++ b/runeq/resources/org.py
@@ -16,12 +16,7 @@ class Org(ItemBase):
     """
 
     def __init__(
-        self,
-        id: str,
-        name: str,
-        created_at: float,
-        tags: Iterable = (),
-        **attributes
+        self, id: str, name: str, created_at: float, tags: Iterable = (), **attributes
     ):
         """
         Initialize with metadata.
@@ -77,10 +72,10 @@ class Org(ItemBase):
 
         """
         if not org_id.startswith("org-"):
-            org_id = f'org-{org_id}'
+            org_id = f"org-{org_id}"
 
         if not org_id.endswith(",org"):
-            org_id = f'{org_id},org'
+            org_id = f"{org_id},org"
 
         return org_id
 
@@ -114,7 +109,7 @@ def _iter_all_orgs(client: Optional[GraphClient] = None):
 
     """
     client = client or global_graph_client()
-    query = '''
+    query = """
         query getOrgMemberships($cursor: Cursor) {
             user {
                 membershipList(cursor: $cursor) {
@@ -132,17 +127,14 @@ def _iter_all_orgs(client: Optional[GraphClient] = None):
                 }
             }
         }
-    '''
+    """
 
     next_cursor = None
 
     # Use cursor to page through all orgs that the user is a member of. Yield
     # each one as an Org
     while True:
-        result = client.execute(
-            statement=query,
-            cursor=next_cursor
-        )
+        result = client.execute(statement=query, cursor=next_cursor)
 
         membership_list = result.get("user", {}).get("membershipList", {})
 
@@ -195,10 +187,7 @@ def get_orgs(client: Optional[GraphClient] = None) -> OrgSet:
     return org_set
 
 
-def set_active_org(
-    org: Union[str, Org],
-    client: Optional[GraphClient] = None
-) -> Org:
+def set_active_org(org: Union[str, Org], client: Optional[GraphClient] = None) -> Org:
     """
     Set the active organization for the current user.
 
@@ -214,7 +203,7 @@ def set_active_org(
     client = client or global_graph_client()
     org_id = org.id if isinstance(org, Org) else org
 
-    statement = '''
+    statement = """
     mutation updateDefaultMembership($input: UpdateDefaultMembershipInput!) {
         updateDefaultMembership(input: $input) {
             user {
@@ -229,7 +218,7 @@ def set_active_org(
             }
         }
     }
-    '''
+    """
 
     result = client.execute(statement=statement, input={"orgId": org_id})
 

--- a/runeq/resources/patient.py
+++ b/runeq/resources/patient.py
@@ -26,7 +26,7 @@ class Device(ItemBase):
         name: str,
         created_at: float,
         device_type_id: str,
-        **attributes
+        **attributes,
     ):
         """
         Initialize with metadata.
@@ -84,7 +84,7 @@ class Device(ItemBase):
         norm_patient_id = Patient.normalize_id(patient_id)
         norm_device_id = Device.normalize_id(device_id)
 
-        return f'patient-{norm_patient_id},device-{norm_device_id}'
+        return f"patient-{norm_patient_id},device-{norm_device_id}"
 
     def __repr__(self):
         """
@@ -131,12 +131,7 @@ class Patient(ItemBase):
     """
 
     def __init__(
-        self,
-        id: str,
-        name: str,
-        created_at: float,
-        devices: DeviceSet,
-        **attributes
+        self, id: str, name: str, created_at: float, devices: DeviceSet, **attributes
     ):
         """
         Initialize with metadata.
@@ -187,7 +182,7 @@ class Patient(ItemBase):
 
         """
         if not patient_id.startswith("patient-"):
-            patient_id = f'patient-{patient_id}'
+            patient_id = f"patient-{patient_id}"
 
         return patient_id
 
@@ -255,10 +250,7 @@ class PatientSet(ItemSet):
         return all_devices
 
 
-def get_patient(
-    patient_id: str,
-    client: Optional[GraphClient] = None
-) -> Patient:
+def get_patient(patient_id: str, client: Optional[GraphClient] = None) -> Patient:
     """
     Get the patient with the specified patient ID.
 
@@ -269,7 +261,7 @@ def get_patient(
 
     """
     client = client or global_graph_client()
-    query = '''
+    query = """
         query getPatient($patient_id: ID!, $cursor: Cursor) {
             patient(id: $patient_id) {
                 id
@@ -293,7 +285,7 @@ def get_patient(
                 }
             }
         }
-    '''
+    """
 
     patient_id = Patient.normalize_id(patient_id)
     patient_attrs = {}
@@ -304,9 +296,7 @@ def get_patient(
     # Use cursor to page through all patient devices
     while True:
         result = client.execute(
-            statement=query,
-            patient_id=patient_id,
-            cursor=next_cursor
+            statement=query, patient_id=patient_id, cursor=next_cursor
         )
 
         patient_attrs = result["patient"]
@@ -314,14 +304,11 @@ def get_patient(
         # Add the patient's devices to device_set
         device_list = patient_attrs.get("deviceList", {})
         for device_attrs in device_list.get("devices", []):
-            device_type = device_attrs['device_type']
-            device_attrs['device_type_id'] = device_type['id']
-            del device_attrs['device_type']
+            device_type = device_attrs["device_type"]
+            device_attrs["device_type_id"] = device_type["id"]
+            del device_attrs["device_type"]
 
-            device = Device(
-                patient_id=patient_id,
-                **device_attrs
-            )
+            device = Device(patient_id=patient_id, **device_attrs)
             device_set.add(device)
 
         # next_cursor is None when there are no more devices for this patient
@@ -343,7 +330,7 @@ def get_all_patients(client: Optional[GraphClient] = None) -> PatientSet:
 
     """
     client = client or global_graph_client()
-    patients_query = '''
+    patients_query = """
         query getPatientList($patient_cursor: Cursor, $device_cursor: Cursor) {
             org {
                 patientAccessList(cursor: $patient_cursor) {
@@ -376,7 +363,7 @@ def get_all_patients(client: Optional[GraphClient] = None) -> PatientSet:
                 }
             }
         }
-    '''
+    """
 
     patient_cursor = None
     patient_set = PatientSet()
@@ -399,14 +386,11 @@ def get_all_patients(client: Optional[GraphClient] = None) -> PatientSet:
             device_set = DeviceSet()
             device_list = patient_attrs.get("deviceList", {})
             for device_attrs in device_list.get("devices", []):
-                device_type = device_attrs['device_type']
-                device_attrs['device_type_id'] = device_type['id']
-                del device_attrs['device_type']
+                device_type = device_attrs["device_type"]
+                device_attrs["device_type_id"] = device_type["id"]
+                del device_attrs["device_type"]
 
-                device = Device(
-                    patient_id=patient_id,
-                    **device_attrs
-                )
+                device = Device(patient_id=patient_id, **device_attrs)
                 device_set.add(device)
 
             device_cursor = device_list.get("pageInfo", {}).get("endCursor")

--- a/runeq/resources/project.py
+++ b/runeq/resources/project.py
@@ -4,6 +4,7 @@ Fetch metadata about projects.
 """
 
 from typing import Iterable, Optional, Type
+
 import pandas as pd
 
 from .client import GraphClient, global_graph_client
@@ -17,6 +18,7 @@ class Metric(ItemBase):
     are calculated periodically and updated.
 
     """
+
     def __init__(
         self,
         id: str,
@@ -70,6 +72,7 @@ class MetricSet(ItemSet):
     A collection of Metrics.
 
     """
+
     def __init__(self, items: Iterable[Metric] = ()):
         """
         Initialize with Metrics.
@@ -92,6 +95,7 @@ class ProjectPatientMetadata(ItemBase):
     associated with the project.
 
     """
+
     def __init__(
         self,
         id: str,
@@ -161,12 +165,12 @@ class ProjectPatientMetadata(ItemBase):
 
         return pd.concat(
             [
-                metadata_df.drop('metrics', axis=1),
-                pd.DataFrame(metadata_df['metrics'].tolist()).rename(
+                metadata_df.drop("metrics", axis=1),
+                pd.DataFrame(metadata_df["metrics"].tolist()).rename(
                     columns=column_name_map
-                )
+                ),
             ],
-            axis=1
+            axis=1,
         )
 
 
@@ -175,6 +179,7 @@ class CohortPatientMetadata(ProjectPatientMetadata):
     Cohort related information about a patient contained in a cohort.
 
     """
+
     def __init__(
         self,
         id: str,
@@ -264,6 +269,7 @@ class Cohort(ItemBase):
     A single project can have multiple cohorts.
 
     """
+
     def __init__(
         self,
         id: str,
@@ -336,6 +342,7 @@ class Project(ItemBase):
     on a regular basis for all patients in a project.
 
     """
+
     def __init__(
         self,
         id: str,
@@ -426,9 +433,7 @@ class ProjectSet(ItemSet):
         return Project
 
 
-def get_project(
-    project_id: str, client: Optional[GraphClient] = None
-) -> Project:
+def get_project(project_id: str, client: Optional[GraphClient] = None) -> Project:
     """
     Get the project with the specified ID.
 
@@ -561,9 +566,7 @@ def get_projects(client: Optional[GraphClient] = None) -> ProjectSet:
     return project_set
 
 
-def _parse_patient_metrics(
-    metrics: dict
-) -> MetricSet:
+def _parse_patient_metrics(metrics: dict) -> MetricSet:
     """
     Helper function that intakes a metric dictionary and outputs a metric set.
 
@@ -659,9 +662,7 @@ def get_project_patients(
         if not cursor:
             break
 
-        cursor_input = {
-            "codeNameCursor": cursor
-        }
+        cursor_input = {"codeNameCursor": cursor}
 
     return project_patient_set
 
@@ -740,15 +741,11 @@ def get_cohort_patients(
             patient = CohortPatientMetadata(**patient_attrs)
             cohort_patient_set.add(patient)
 
-        cursor = cohort_patient_list.get("pageInfo", {}).get(
-            "codeNameEndCursor"
-        )
+        cursor = cohort_patient_list.get("pageInfo", {}).get("codeNameEndCursor")
 
         if not cursor:
             break
 
-        cursor_input = {
-            "codeNameCursor": cursor
-        }
+        cursor_input = {"codeNameCursor": cursor}
 
     return cohort_patient_set

--- a/runeq/resources/stream.py
+++ b/runeq/resources/stream.py
@@ -2,12 +2,11 @@
 Query data directly from the V2 Stream API.
 
 """
-from datetime import date, datetime
 import time
+from datetime import date, datetime
 from typing import Iterable, Iterator, Optional, Union
 
 from .client import StreamClient, global_stream_client
-
 
 _time_type = Union[int, float, date, datetime]
 
@@ -35,7 +34,7 @@ def get_stream_data(
     timezone: Optional[int] = None,
     timezone_name: Optional[str] = None,
     translate_enums: Optional[bool] = True,
-    client: Optional[StreamClient] = None
+    client: Optional[StreamClient] = None,
 ) -> Iterator[Union[str, dict]]:
     """
     Fetch raw data for a stream.
@@ -81,14 +80,10 @@ def get_stream_data(
 
     """
     if start_time and start_time_ns:
-        raise ValueError(
-            "only start_time or start_time_ns can be defined, not both."
-        )
+        raise ValueError("only start_time or start_time_ns can be defined, not both.")
 
     if end_time and end_time_ns:
-        raise ValueError(
-            "only end_time or end_time_ns can be defined, not both."
-        )
+        raise ValueError("only end_time or end_time_ns can be defined, not both.")
 
     start_time = _time_type_to_unix_secs(start_time)
     end_time = _time_type_to_unix_secs(end_time)
@@ -118,13 +113,13 @@ def get_stream_availability(
     end_time: _time_type,
     resolution: int,
     batch_operation: Optional[str] = None,
-    format: Optional[str] = 'csv',
+    format: Optional[str] = "csv",
     limit: Optional[int] = None,
     page_token: Optional[str] = None,
-    timestamp: Optional[str] = 'iso',
+    timestamp: Optional[str] = "iso",
     timezone: Optional[int] = None,
     timezone_name: Optional[str] = None,
-    client: Optional[StreamClient] = None
+    client: Optional[StreamClient] = None,
 ) -> Iterator[Union[str, dict]]:
     """
     Fetch the availability of 1 or multiple streams. When multiple stream
@@ -178,16 +173,16 @@ def get_stream_availability(
 
     """
     params = {
-        'start_time': _time_type_to_unix_secs(start_time),
-        'end_time': _time_type_to_unix_secs(end_time),
-        'resolution': resolution,
-        'batch_operation': batch_operation,
-        'format': format,
-        'limit': limit,
-        'page_token': page_token,
-        'timestamp': timestamp,
-        'timezone': timezone,
-        'timezone_name': timezone_name,
+        "start_time": _time_type_to_unix_secs(start_time),
+        "end_time": _time_type_to_unix_secs(end_time),
+        "resolution": resolution,
+        "batch_operation": batch_operation,
+        "format": format,
+        "limit": limit,
+        "page_token": page_token,
+        "timestamp": timestamp,
+        "timezone": timezone,
+        "timezone_name": timezone_name,
     }
 
     client = client or global_stream_client()

--- a/runeq/resources/user.py
+++ b/runeq/resources/user.py
@@ -78,7 +78,7 @@ def get_current_user(client: Optional[GraphClient] = None) -> User:
             API. Otherwise, the global GraphClient is used.
     """
     client = client or global_graph_client()
-    query = '''
+    query = """
         query getUser {
             user {
                 id
@@ -93,7 +93,7 @@ def get_current_user(client: Optional[GraphClient] = None) -> User:
                 email
             }
         }
-    '''
+    """
 
     result = client.execute(statement=query)
 
@@ -107,5 +107,5 @@ def get_current_user(client: Optional[GraphClient] = None) -> User:
         created_at=user_attrs.get("created_at"),
         active_org_id=org.get("id"),
         active_org_name=org.get("name"),
-        email=user_attrs.get("email")
+        email=user_attrs.get("email"),
     )

--- a/runeq/stream/__init__.py
+++ b/runeq/stream/__init__.py
@@ -2,6 +2,6 @@ from . import v1
 from .v1 import V1Client
 
 __all__ = [
-    'v1',
-    'V1Client',
+    "v1",
+    "V1Client",
 ]

--- a/setup.py
+++ b/setup.py
@@ -1,39 +1,39 @@
 from setuptools import find_packages, setup
 
-package_name = 'runeq'
+package_name = "runeq"
 
-with open('README.md') as r:
+with open("README.md") as r:
     long_description = r.read()
 
-with open('requirements/common.txt', 'r') as r:
+with open("requirements/common.txt", "r") as r:
     install_requires = r.read().splitlines()
 
 setup(
     name=package_name,
-    version='0.13.1',
-    author='Rune Labs',
-    maintainer_email='support@runelabs.io',
-    description='Query data from Rune Labs APIs',
+    version="0.13.1",
+    author="Rune Labs",
+    maintainer_email="support@runelabs.io",
+    description="Query data from Rune Labs APIs",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    keywords='rune labs api query data',
-    url='https://github.com/rune-labs/runeq-python',
+    long_description_content_type="text/markdown",
+    keywords="rune labs api query data",
+    url="https://github.com/rune-labs/runeq-python",
     packages=find_packages(),
     install_requires=install_requires,
-    test_suite='tests',
+    test_suite="tests",
     classifiers=[
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     entry_points={
-        'console_scripts': [
-            'runeq=cli:cli',
+        "console_scripts": [
+            "runeq=cli:cli",
         ],
     },
 )

--- a/tests/resources/test_client.py
+++ b/tests/resources/test_client.py
@@ -2,10 +2,10 @@
 Tests for the V2 SDK Client.
 
 """
-from unittest import mock, TestCase
+from unittest import TestCase, mock
 
 from runeq import errors
-from runeq.resources.client import initialize, GraphClient, StreamClient
+from runeq.resources.client import GraphClient, StreamClient, initialize
 from runeq.resources.stream import get_stream_data
 
 
@@ -33,10 +33,7 @@ class TestInitialize(TestCase):
             access_token_secret="bar",
         )
 
-        with self.assertRaisesRegex(
-            errors.APIError,
-            "401 InvalidAuthentication"
-        ):
+        with self.assertRaisesRegex(errors.APIError, "401 InvalidAuthentication"):
             get_stream_data("stream_id").__next__()
 
     def test_init_with_client_keys(self):
@@ -49,10 +46,7 @@ class TestInitialize(TestCase):
             client_access_key="bar",
         )
 
-        with self.assertRaisesRegex(
-            errors.APIError,
-            "401 InvalidAuthentication"
-        ):
+        with self.assertRaisesRegex(errors.APIError, "401 InvalidAuthentication"):
             get_stream_data("stream_id").__next__()
 
 
@@ -70,11 +64,11 @@ class TestStreamClient(TestCase):
         mock_response.json.return_value = json_body
         return mock_response
 
-    @mock.patch('runeq.resources.client.requests.get')
+    @mock.patch("runeq.resources.client.requests.get")
     def test_refresh_auth_on_4xx(self, mock_get):
         """If a request fails with a 4xx status code, refresh auth and retry"""
         config = mock.Mock()
-        config.stream_url = ''
+        config.stream_url = ""
         config.refresh_auth.return_value = True
 
         stream_client = StreamClient(config)
@@ -83,16 +77,16 @@ class TestStreamClient(TestCase):
         mock_get.return_value = mock_response
 
         with self.assertRaises(errors.APIError):
-            list(stream_client.get_data('/v2/streams/123'))
+            list(stream_client.get_data("/v2/streams/123"))
 
         self.assertEqual(mock_get.call_count, 2)
         config.refresh_auth.assert_called_once()
 
-    @mock.patch('runeq.resources.client.requests.get')
+    @mock.patch("runeq.resources.client.requests.get")
     def test_no_retry_on_5xx(self, mock_get):
         """If a request fails with a 5xx status code, do not retry"""
         config = mock.Mock()
-        config.stream_url = ''
+        config.stream_url = ""
         config.refresh_auth.return_value = True
 
         stream_client = StreamClient(config)
@@ -101,7 +95,7 @@ class TestStreamClient(TestCase):
         mock_get.return_value = mock_response
 
         with self.assertRaises(errors.APIError):
-            list(stream_client.get_data('/v2/streams/123'))
+            list(stream_client.get_data("/v2/streams/123"))
 
         self.assertEqual(mock_get.call_count, 1)
         config.refresh_auth.assert_not_called()
@@ -113,23 +107,21 @@ class TestGraphClient(TestCase):
 
     """
 
-    @mock.patch('runeq.resources.client.GQLClient')
+    @mock.patch("runeq.resources.client.GQLClient")
     def test_refresh_auth_on_error(self, mock_client_cls):
         """If a request fails with any error, refresh auth and retry"""
         config = mock.Mock()
-        config.graph_url = ''
-        config.auth_headers = {'hello': 'world'}
+        config.graph_url = ""
+        config.auth_headers = {"hello": "world"}
 
         graph_client = GraphClient(config)
 
         mock_execute = mock_client_cls().execute
-        excecute_err = ValueError('test exception')
+        excecute_err = ValueError("test exception")
         mock_execute.side_effect = excecute_err
 
-        with self.assertRaisesRegex(ValueError, 'test exception'):
-            graph_client.execute(
-                'query fakeQuery($input: Input) { id }'
-            )
+        with self.assertRaisesRegex(ValueError, "test exception"):
+            graph_client.execute("query fakeQuery($input: Input) { id }")
 
         self.assertEqual(mock_execute.call_count, 2)
         config.refresh_auth.assert_called_once()

--- a/tests/resources/test_common.py
+++ b/tests/resources/test_common.py
@@ -43,6 +43,7 @@ class PatientItemSet(ItemSet):
     Test ItemSet class that represents a Patient
 
     """
+
     def __init__(self, items: List[PatientItem] = []):
         """
         Initializes PatientItemSet
@@ -111,16 +112,14 @@ class TestItemBase(TestCase):
         # Class that has a name attribute
         patient = PatientItem(id="patient_id1", name="Patient 1", key1="val1")
         self.assertEqual(
-            'PatientItem(id="patient_id1", name="Patient 1")',
-            repr(patient)
+            'PatientItem(id="patient_id1", name="Patient 1")', repr(patient)
         )
 
         # Class that doesn't have a name attribute
-        stream = StreamItem(id="stream-123", )
-        self.assertEqual(
-            'StreamItem(id="stream-123")',
-            repr(stream)
+        stream = StreamItem(
+            id="stream-123",
         )
+        self.assertEqual('StreamItem(id="stream-123")', repr(stream))
 
     def test_to_dict(self):
         """
@@ -130,20 +129,10 @@ class TestItemBase(TestCase):
         patient1 = PatientItem(id="patient_id")
         self.assertEqual({"id": "patient_id", "name": ""}, patient1.to_dict())
 
-        patient2 = PatientItem(
-            id="patient_id",
-            name='Patient 2',
-            key1="val1",
-            key2=2
-        )
+        patient2 = PatientItem(id="patient_id", name="Patient 2", key1="val1", key2=2)
         self.assertEqual(
-            {
-                "id": "patient_id",
-                "name": "Patient 2",
-                "key1": "val1",
-                "key2": 2
-            },
-            patient2.to_dict()
+            {"id": "patient_id", "name": "Patient 2", "key1": "val1", "key2": 2},
+            patient2.to_dict(),
         )
 
 
@@ -171,7 +160,7 @@ class TestItemSet(TestCase):
         Test __iter__
 
         """
-        exp_patient_ids = ['patient1_id', 'patient2_id', 'patient3_id']
+        exp_patient_ids = ["patient1_id", "patient2_id", "patient3_id"]
         for patient in self.test_patient_set:
             self.assertIn(patient.id, exp_patient_ids)
             exp_patient_ids.remove(patient.id)
@@ -193,14 +182,13 @@ class TestItemSet(TestCase):
         """
         # __getitem__
         self.assertEqual(
-            PatientItem(id="patient1_id"),
-            self.test_patient_set["patient1_id"]
+            PatientItem(id="patient1_id"), self.test_patient_set["patient1_id"]
         )
 
         # get
         self.assertEqual(
             PatientItem(id="patient2_id", key1="val1"),
-            self.test_patient_set.get("patient2_id")
+            self.test_patient_set.get("patient2_id"),
         )
 
     def test_add(self):
@@ -217,8 +205,7 @@ class TestItemSet(TestCase):
 
         patient_set.add(patient2)
         self.assertEqual(2, len(patient_set))
-        self.assertEqual({"patient1_id", "patient2_id"},
-                         set(patient_set.ids()))
+        self.assertEqual({"patient1_id", "patient2_id"}, set(patient_set.ids()))
 
         # Test raises TypeError when adding item with a different
         # type to the set.
@@ -256,10 +243,7 @@ class TestItemSet(TestCase):
         self.assertEqual(1, len(patient_set2))
 
         # Test raises TypeError when adding ItemSets with different types
-        with self.assertRaisesRegex(
-            TypeError,
-            "cannot update with PatientItem"
-        ):
+        with self.assertRaisesRegex(TypeError, "cannot update with PatientItem"):
             OrgSet().update(patient_set)
 
     def test_remove(self):
@@ -301,14 +285,11 @@ class TestItemSet(TestCase):
         Test ids
 
         """
-        self.assertEqual(
-            [],
-            list(PatientItemSet().ids())
-        )
+        self.assertEqual([], list(PatientItemSet().ids()))
 
         self.assertEqual(
             ["patient1_id", "patient2_id", "patient3_id"],
-            list(self.test_patient_set.ids())
+            list(self.test_patient_set.ids()),
         )
 
     def test_repr(self):
@@ -319,7 +300,7 @@ class TestItemSet(TestCase):
         self.assertEqual(
             """PatientItemSet {
 }""",
-            repr(PatientItemSet())
+            repr(PatientItemSet()),
         )
 
         patient_set = PatientItemSet(
@@ -334,16 +315,15 @@ class TestItemSet(TestCase):
 
         self.assertEqual(
             (
-                'PatientItemSet {\n'
+                "PatientItemSet {\n"
                 '	PatientItem(id="patient1_id", name="")\n'
                 '	PatientItem(id="patient2_id", name="Patient 2")\n'
                 '	PatientItem(id="patient3_id", name="Patient 3")\n'
-                '	... (and 2 others)\n'
-                '}'
+                "	... (and 2 others)\n"
+                "}"
             ),
-            str(patient_set)
+            str(patient_set),
         )
-
 
     def test_to_list(self):
         """
@@ -353,10 +333,9 @@ class TestItemSet(TestCase):
         self.assertEqual([], PatientItemSet().to_list())
         self.assertEqual(
             [
-                {'id': 'patient1_id', 'name': 'Patient 1'},
-                {'id': 'patient2_id', 'key1': 'val1', 'name': ''},
-                {'id': 'patient3_id', 'key1': 1, 'key2': 'val2', 'name': ''},
+                {"id": "patient1_id", "name": "Patient 1"},
+                {"id": "patient2_id", "key1": "val1", "name": ""},
+                {"id": "patient3_id", "key1": 1, "key2": "val2", "name": ""},
             ],
-            self.test_patient_set.to_list()
+            self.test_patient_set.to_list(),
         )
-

--- a/tests/resources/test_org.py
+++ b/tests/resources/test_org.py
@@ -6,12 +6,7 @@ from unittest import TestCase, mock
 
 from runeq.config import Config
 from runeq.resources.client import GraphClient
-from runeq.resources.org import (
-    get_org,
-    get_orgs,
-    Org,
-    set_active_org
-)
+from runeq.resources.org import Org, get_org, get_orgs, set_active_org
 
 
 class TestOrg(TestCase):
@@ -26,10 +21,7 @@ class TestOrg(TestCase):
 
         """
         self.mock_client = GraphClient(
-            Config(
-                client_key_id='test',
-                client_access_key='config'
-            )
+            Config(client_key_id="test", client_access_key="config")
         )
 
     def test_attributes(self):
@@ -59,10 +51,7 @@ class TestOrg(TestCase):
             created_at=1629300943.9179766,
             name="Org 1",
         )
-        self.assertEqual(
-            'Org(id="org1-id", name="Org 1")',
-            repr(test_org)
-        )
+        self.assertEqual('Org(id="org1-id", name="Org 1")', repr(test_org))
 
     def test_normalize_id(self):
         """
@@ -71,22 +60,22 @@ class TestOrg(TestCase):
         """
         self.assertEqual(
             "d4b1c627bd464fe0a5ed940cc8e8e485",
-            Org.normalize_id("org-d4b1c627bd464fe0a5ed940cc8e8e485,org")
+            Org.normalize_id("org-d4b1c627bd464fe0a5ed940cc8e8e485,org"),
         )
 
         self.assertEqual(
             "d4b1c627bd464fe0a5ed940cc8e8e485",
-            Org.normalize_id("d4b1c627bd464fe0a5ed940cc8e8e485,org")
+            Org.normalize_id("d4b1c627bd464fe0a5ed940cc8e8e485,org"),
         )
 
         self.assertEqual(
             "d4b1c627bd464fe0a5ed940cc8e8e485",
-            Org.normalize_id("org-d4b1c627bd464fe0a5ed940cc8e8e485")
+            Org.normalize_id("org-d4b1c627bd464fe0a5ed940cc8e8e485"),
         )
 
         self.assertEqual(
             "d4b1c627bd464fe0a5ed940cc8e8e485",
-            Org.normalize_id("d4b1c627bd464fe0a5ed940cc8e8e485")
+            Org.normalize_id("d4b1c627bd464fe0a5ed940cc8e8e485"),
         )
 
     def test_denormalize_id(self):
@@ -96,22 +85,22 @@ class TestOrg(TestCase):
         """
         self.assertEqual(
             "org-d4b1c627bd464fe0a5ed940cc8e8e485,org",
-            Org.denormalize_id("org-d4b1c627bd464fe0a5ed940cc8e8e485,org")
+            Org.denormalize_id("org-d4b1c627bd464fe0a5ed940cc8e8e485,org"),
         )
 
         self.assertEqual(
             "org-d4b1c627bd464fe0a5ed940cc8e8e485,org",
-            Org.denormalize_id("d4b1c627bd464fe0a5ed940cc8e8e485,org")
+            Org.denormalize_id("d4b1c627bd464fe0a5ed940cc8e8e485,org"),
         )
 
         self.assertEqual(
             "org-d4b1c627bd464fe0a5ed940cc8e8e485,org",
-            Org.denormalize_id("org-d4b1c627bd464fe0a5ed940cc8e8e485")
+            Org.denormalize_id("org-d4b1c627bd464fe0a5ed940cc8e8e485"),
         )
 
         self.assertEqual(
             "org-d4b1c627bd464fe0a5ed940cc8e8e485,org",
-            Org.denormalize_id("d4b1c627bd464fe0a5ed940cc8e8e485")
+            Org.denormalize_id("d4b1c627bd464fe0a5ed940cc8e8e485"),
         )
 
     def test_get_org(self):
@@ -119,33 +108,33 @@ class TestOrg(TestCase):
         Test get org for specified org_id.
 
         """
-        self.mock_client.execute = mock.Mock(return_value={
-            "user": {
-                "membershipList": {
-                    "pageInfo": {
-                        "endCursor": None
-                    },
-                    "memberships": [
-                        {
-                            "org": {
-                                "id": "org1-id",
-                                "created_at": 1571267538.391721,
-                                "name": "org1",
-                                "tags": []
-                            }
-                        },
-                        {
-                            "org": {
-                                "id": "org2-id",
-                                "created_at": 1630515986.9949625,
-                                "name": "org2",
-                                "tags": ["tag1", "tag2"]
-                            }
-                        }
-                    ]
+        self.mock_client.execute = mock.Mock(
+            return_value={
+                "user": {
+                    "membershipList": {
+                        "pageInfo": {"endCursor": None},
+                        "memberships": [
+                            {
+                                "org": {
+                                    "id": "org1-id",
+                                    "created_at": 1571267538.391721,
+                                    "name": "org1",
+                                    "tags": [],
+                                }
+                            },
+                            {
+                                "org": {
+                                    "id": "org2-id",
+                                    "created_at": 1630515986.9949625,
+                                    "name": "org2",
+                                    "tags": ["tag1", "tag2"],
+                                }
+                            },
+                        ],
+                    }
                 }
             }
-        })
+        )
 
         org = get_org("org1-id", client=self.mock_client)
         self.assertEqual(
@@ -164,7 +153,7 @@ class TestOrg(TestCase):
                 "id": "org2-id",
                 "created_at": 1630515986.9949625,
                 "name": "org2",
-                "tags": ["tag1", "tag2"]
+                "tags": ["tag1", "tag2"],
             },
             org.to_dict(),
         )
@@ -179,16 +168,14 @@ class TestOrg(TestCase):
             {
                 "user": {
                     "membershipList": {
-                        "pageInfo": {
-                            "endCursor": None
-                        },
+                        "pageInfo": {"endCursor": None},
                         "memberships": [
                             {
                                 "org": {
                                     "id": "org1-id",
                                     "created_at": 1571267538.391721,
                                     "name": "org1",
-                                    "tags": ["tag1"]
+                                    "tags": ["tag1"],
                                 }
                             },
                             {
@@ -196,7 +183,7 @@ class TestOrg(TestCase):
                                     "id": "org2-id",
                                     "created_at": 1630515986.9949625,
                                     "name": "org2",
-                                    "tags": ["tag2"]
+                                    "tags": ["tag2"],
                                 }
                             },
                             {
@@ -204,10 +191,10 @@ class TestOrg(TestCase):
                                     "id": "org3-id",
                                     "created_at": 1649888079.066764,
                                     "name": "org3",
-                                    "tags": []
+                                    "tags": [],
                                 }
-                            }
-                        ]
+                            },
+                        ],
                     }
                 }
             }
@@ -218,23 +205,23 @@ class TestOrg(TestCase):
         self.assertEqual(
             [
                 {
-                    'created_at': 1571267538.391721,
-                    'name': 'org1',
-                    'id': 'org1-id',
-                    'tags': ['tag1']
+                    "created_at": 1571267538.391721,
+                    "name": "org1",
+                    "id": "org1-id",
+                    "tags": ["tag1"],
                 },
                 {
-                    'created_at': 1630515986.9949625,
-                    'name': 'org2',
-                    'id': 'org2-id',
-                    'tags': ['tag2']
+                    "created_at": 1630515986.9949625,
+                    "name": "org2",
+                    "id": "org2-id",
+                    "tags": ["tag2"],
                 },
                 {
-                    'created_at': 1649888079.066764,
-                    'name': 'org3',
-                    'id': 'org3-id',
-                    'tags': [],
-                }
+                    "created_at": 1649888079.066764,
+                    "name": "org3",
+                    "id": "org3-id",
+                    "tags": [],
+                },
             ],
             orgs.to_list(),
         )
@@ -250,41 +237,37 @@ class TestOrg(TestCase):
             {
                 "user": {
                     "membershipList": {
-                        "pageInfo": {
-                            "endCursor": "test_check_next"
-                        },
+                        "pageInfo": {"endCursor": "test_check_next"},
                         "memberships": [
                             {
                                 "org": {
                                     "id": "org1-id",
                                     "created_at": 1571267538.391721,
                                     "name": "org1",
-                                    "tags": []
+                                    "tags": [],
                                 }
                             }
-                        ]
+                        ],
                     }
                 }
             },
             {
                 "user": {
                     "membershipList": {
-                        "pageInfo": {
-                            "endCursor": None
-                        },
+                        "pageInfo": {"endCursor": None},
                         "memberships": [
                             {
                                 "org": {
                                     "id": "org2-id",
                                     "created_at": 1630515986.9949625,
                                     "name": "org2",
-                                    "tags": []
+                                    "tags": [],
                                 }
                             }
-                        ]
+                        ],
                     }
                 }
-            }
+            },
         ]
 
         orgs = get_orgs(client=self.mock_client)
@@ -292,17 +275,17 @@ class TestOrg(TestCase):
         self.assertEqual(
             [
                 {
-                    'created_at': 1571267538.391721,
-                    'name': 'org1',
-                    'id': 'org1-id',
-                    'tags': [],
+                    "created_at": 1571267538.391721,
+                    "name": "org1",
+                    "id": "org1-id",
+                    "tags": [],
                 },
                 {
-                    'created_at': 1630515986.9949625,
-                    'name': 'org2',
-                    'id': 'org2-id',
-                    'tags': [],
-                }
+                    "created_at": 1630515986.9949625,
+                    "name": "org2",
+                    "id": "org2-id",
+                    "tags": [],
+                },
             ],
             orgs.to_list(),
         )
@@ -323,7 +306,7 @@ class TestOrg(TestCase):
                                 "id": org_id,
                                 "name": "org1",
                                 "created_at": 1571267538.391721,
-                                'tags': ['tag1']
+                                "tags": ["tag1"],
                             }
                         }
                     }
@@ -336,9 +319,9 @@ class TestOrg(TestCase):
         self.assertEqual(
             new_org.to_dict(),
             {
-                'created_at': 1571267538.391721,
-                'name': 'org1',
-                'id': 'org1-id',
-                'tags': ['tag1']
-            }
+                "created_at": 1571267538.391721,
+                "name": "org1",
+                "id": "org1-id",
+                "tags": ["tag1"],
+            },
         )

--- a/tests/resources/test_patient.py
+++ b/tests/resources/test_patient.py
@@ -7,8 +7,15 @@ from unittest import TestCase, mock
 from runeq.config import Config
 from runeq.resources.client import GraphClient
 from runeq.resources.patient import (
-    Device, DeviceSet, Patient, PatientSet, get_all_devices, get_all_patients,
-    get_device, get_patient, get_patient_devices
+    Device,
+    DeviceSet,
+    Patient,
+    PatientSet,
+    get_all_devices,
+    get_all_patients,
+    get_device,
+    get_patient,
+    get_patient_devices,
 )
 
 
@@ -24,10 +31,7 @@ class TestPatient(TestCase):
 
         """
         self.mock_client = GraphClient(
-            Config(
-                client_key_id='test',
-                client_access_key='config'
-            )
+            Config(client_key_id="test", client_access_key="config")
         )
 
     def test_attributes(self):
@@ -54,9 +58,9 @@ class TestPatient(TestCase):
                         name="Apple Watch",
                         created_at=1629300943.9179766,
                         device_type_id="dt2",
-                    )
+                    ),
                 ]
-            )
+            ),
         )
 
         self.assertEqual("p1", test_patient.id)
@@ -74,7 +78,7 @@ class TestPatient(TestCase):
                 "created_at": 1629300943.9179766,
                 "device_type_id": "dt1",
             },
-            actual_devices[0]
+            actual_devices[0],
         )
 
         self.assertEqual(
@@ -85,7 +89,7 @@ class TestPatient(TestCase):
                 "created_at": 1629300943.9179766,
                 "device_type_id": "dt2",
             },
-            actual_devices[1]
+            actual_devices[1],
         )
 
         self.assertEqual(
@@ -96,7 +100,7 @@ class TestPatient(TestCase):
                 created_at=1629300943.9179766,
                 device_type_id="dt1",
             ),
-            test_patient.device("d1")
+            test_patient.device("d1"),
         )
 
     def test_repr(self):
@@ -108,12 +112,9 @@ class TestPatient(TestCase):
             id="p1",
             created_at=1629300943.9179766,
             name="Patient 1",
-            devices=DeviceSet()
+            devices=DeviceSet(),
         )
-        self.assertEqual(
-            'Patient(id="p1", name="Patient 1")',
-            repr(test_patient)
-        )
+        self.assertEqual('Patient(id="p1", name="Patient 1")', repr(test_patient))
 
     def test_normalize_id(self):
         """
@@ -122,12 +123,12 @@ class TestPatient(TestCase):
         """
         self.assertEqual(
             "d4b1c627bd464fe0a5ed940cc8e8e485",
-            Patient.normalize_id("patient-d4b1c627bd464fe0a5ed940cc8e8e485")
+            Patient.normalize_id("patient-d4b1c627bd464fe0a5ed940cc8e8e485"),
         )
 
         self.assertEqual(
             "d4b1c627bd464fe0a5ed940cc8e8e485",
-            Patient.normalize_id("d4b1c627bd464fe0a5ed940cc8e8e485")
+            Patient.normalize_id("d4b1c627bd464fe0a5ed940cc8e8e485"),
         )
 
     def test_denormalize_id(self):
@@ -137,12 +138,12 @@ class TestPatient(TestCase):
         """
         self.assertEqual(
             "patient-d4b1c627bd464fe0a5ed940cc8e8e485",
-            Patient.denormalize_id("patient-d4b1c627bd464fe0a5ed940cc8e8e485")
+            Patient.denormalize_id("patient-d4b1c627bd464fe0a5ed940cc8e8e485"),
         )
 
         self.assertEqual(
             "patient-d4b1c627bd464fe0a5ed940cc8e8e485",
-            Patient.denormalize_id("d4b1c627bd464fe0a5ed940cc8e8e485")
+            Patient.denormalize_id("d4b1c627bd464fe0a5ed940cc8e8e485"),
         )
 
     def test_get_patient_basic(self):
@@ -158,48 +159,37 @@ class TestPatient(TestCase):
                     "created_at": 1630515986.9949625,
                     "name": "patient1",
                     "deviceList": {
-                        "pageInfo": {
-                            "endCursor": None
-                        },
+                        "pageInfo": {"endCursor": None},
                         "devices": [
                             {
                                 "id": "d1",
                                 "name": "Percept",
                                 "created_at": 1646685476.1367705,
-                                "device_type": {
-                                    "id": "dt1",
-                                    "name": "percept"
-                                },
+                                "device_type": {"id": "dt1", "name": "percept"},
                                 "disabled": False,
                                 "disabled_at": None,
-                                "updated_at": 1646685485.9403558
+                                "updated_at": 1646685485.9403558,
                             },
                             {
                                 "id": "d2",
                                 "name": "Strive PD",
                                 "created_at": 1646684177.194158,
-                                "device_type": {
-                                    "id": "dt2",
-                                    "name": "strivestudy"
-                                },
+                                "device_type": {"id": "dt2", "name": "strivestudy"},
                                 "disabled": False,
                                 "disabled_at": None,
-                                "updated_at": 1646684177.194158
+                                "updated_at": 1646684177.194158,
                             },
                             {
                                 "id": "d3",
                                 "name": "Apple Watch",
                                 "created_at": 1646684177.1942198,
-                                "device_type": {
-                                    "id": "dt3",
-                                    "name": "watch"
-                                },
+                                "device_type": {"id": "dt3", "name": "watch"},
                                 "disabled": True,
                                 "disabled_at": 1646684178.1942198,
-                                "updated_at": 1646684178.1942198
+                                "updated_at": 1646684178.1942198,
                             },
-                        ]
-                    }
+                        ],
+                    },
                 }
             }
         ]
@@ -220,7 +210,7 @@ class TestPatient(TestCase):
                         "disabled": False,
                         "disabled_at": None,
                         "updated_at": 1646685485.9403558,
-                        "id": "d1"
+                        "id": "d1",
                     },
                     {
                         "patient_id": "p1",
@@ -230,7 +220,7 @@ class TestPatient(TestCase):
                         "disabled": False,
                         "disabled_at": None,
                         "updated_at": 1646684177.194158,
-                        "id": "d2"
+                        "id": "d2",
                     },
                     {
                         "patient_id": "p1",
@@ -240,13 +230,12 @@ class TestPatient(TestCase):
                         "disabled": True,
                         "disabled_at": 1646684178.1942198,
                         "updated_at": 1646684178.1942198,
-                        "id": "d3"
-                    }
-                ]
+                        "id": "d3",
+                    },
+                ],
             },
             test_patient.to_dict(),
         )
-
 
     def test_get_patient_paginated(self):
         """
@@ -262,9 +251,7 @@ class TestPatient(TestCase):
                     "created_at": 1630515986.9949625,
                     "name": "patient1",
                     "deviceList": {
-                        "pageInfo": {
-                            "endCursor": "test_check_next"
-                        },
+                        "pageInfo": {"endCursor": "test_check_next"},
                         "devices": [
                             {
                                 "id": "d1",
@@ -275,10 +262,10 @@ class TestPatient(TestCase):
                                 },
                                 "disabled": False,
                                 "disabled_at": None,
-                                "updated_at": 1646685485.9403558
+                                "updated_at": 1646685485.9403558,
                             }
-                        ]
-                    }
+                        ],
+                    },
                 }
             },
             {
@@ -287,9 +274,7 @@ class TestPatient(TestCase):
                     "created_at": 1630515986.9949625,
                     "name": "patient1",
                     "deviceList": {
-                        "pageInfo": {
-                            "endCursor": None
-                        },
+                        "pageInfo": {"endCursor": None},
                         "devices": [
                             {
                                 "id": "d2",
@@ -300,12 +285,12 @@ class TestPatient(TestCase):
                                 },
                                 "disabled": False,
                                 "disabled_at": None,
-                                "updated_at": 1646684177.194158
+                                "updated_at": 1646684177.194158,
                             }
-                        ]
-                    }
+                        ],
+                    },
                 }
-            }
+            },
         ]
 
         test_patient = get_patient("patient-p1", client=self.mock_client)
@@ -324,7 +309,7 @@ class TestPatient(TestCase):
                         "disabled": False,
                         "disabled_at": None,
                         "updated_at": 1646685485.9403558,
-                        "id": "d1"
+                        "id": "d1",
                     },
                     {
                         "patient_id": "p1",
@@ -334,9 +319,9 @@ class TestPatient(TestCase):
                         "disabled": False,
                         "disabled_at": None,
                         "updated_at": 1646684177.194158,
-                        "id": "d2"
-                    }
-                ]
+                        "id": "d2",
+                    },
+                ],
             },
             test_patient.to_dict(),
         )
@@ -352,9 +337,7 @@ class TestPatient(TestCase):
                 "created_at": 1630515986.9949625,
                 "name": "patient1",
                 "deviceList": {
-                    "pageInfo": {
-                        "endCursor": None
-                    },
+                    "pageInfo": {"endCursor": None},
                     "devices": [
                         {
                             "id": "d1",
@@ -365,10 +348,10 @@ class TestPatient(TestCase):
                             },
                             "disabled": False,
                             "disabled_at": None,
-                            "updated_at": 1646685485.9403558
+                            "updated_at": 1646685485.9403558,
                         }
-                    ]
-                }
+                    ],
+                },
             }
         }
 
@@ -378,9 +361,7 @@ class TestPatient(TestCase):
                 "created_at": 1630515986.9949625,
                 "name": "patient2",
                 "deviceList": {
-                    "pageInfo": {
-                        "endCursor": None
-                    },
+                    "pageInfo": {"endCursor": None},
                     "devices": [
                         {
                             "id": "d1",
@@ -391,26 +372,20 @@ class TestPatient(TestCase):
                             },
                             "disabled": False,
                             "disabled_at": None,
-                            "updated_at": 1646685485.9403558
+                            "updated_at": 1646685485.9403558,
                         }
-                    ]
-                }
+                    ],
+                },
             }
         }
-
 
         self.mock_client.execute = mock.Mock()
         self.mock_client.execute.side_effect = [
             {
                 "org": {
                     "patientAccessList": {
-                        "pageInfo": {
-                            "endCursor": None
-                        },
-                        "patientAccess": [
-                            test_patient1,
-                            test_patient2
-                        ]
+                        "pageInfo": {"endCursor": None},
+                        "patientAccess": [test_patient1, test_patient2],
                     }
                 }
             }
@@ -433,9 +408,9 @@ class TestPatient(TestCase):
                             "disabled": False,
                             "disabled_at": None,
                             "updated_at": 1646685485.9403558,
-                            "id": "d1"
+                            "id": "d1",
                         }
-                    ]
+                    ],
                 },
                 {
                     "id": "p2",
@@ -450,14 +425,13 @@ class TestPatient(TestCase):
                             "disabled": False,
                             "disabled_at": None,
                             "updated_at": 1646685485.9403558,
-                            "id": "d1"
+                            "id": "d1",
                         }
-                    ]
-                }
+                    ],
+                },
             ],
             patients.to_list(),
         )
-
 
     def test_get_all_patients_paginated(self):
         """
@@ -471,9 +445,7 @@ class TestPatient(TestCase):
                 "created_at": 1630515986.9949625,
                 "name": "patient1",
                 "deviceList": {
-                    "pageInfo": {
-                        "endCursor": None
-                    },
+                    "pageInfo": {"endCursor": None},
                     "devices": [
                         {
                             "id": "d1",
@@ -484,10 +456,10 @@ class TestPatient(TestCase):
                             },
                             "disabled": False,
                             "disabled_at": None,
-                            "updated_at": 1646685485.9403558
+                            "updated_at": 1646685485.9403558,
                         }
-                    ]
-                }
+                    ],
+                },
             }
         }
 
@@ -497,9 +469,7 @@ class TestPatient(TestCase):
                 "created_at": 1630515986.9949625,
                 "name": "patient2",
                 "deviceList": {
-                    "pageInfo": {
-                        "endCursor": None
-                    },
+                    "pageInfo": {"endCursor": None},
                     "devices": [
                         {
                             "id": "d1",
@@ -510,40 +480,31 @@ class TestPatient(TestCase):
                             },
                             "disabled": False,
                             "disabled_at": None,
-                            "updated_at": 1646685485.9403558
+                            "updated_at": 1646685485.9403558,
                         }
-                    ]
-                }
+                    ],
+                },
             }
         }
-
 
         self.mock_client.execute = mock.Mock()
         self.mock_client.execute.side_effect = [
             {
                 "org": {
                     "patientAccessList": {
-                        "pageInfo": {
-                            "endCursor": "test_check_next"
-                        },
-                        "patientAccess": [
-                            test_patient1
-                        ]
+                        "pageInfo": {"endCursor": "test_check_next"},
+                        "patientAccess": [test_patient1],
                     }
                 }
             },
             {
                 "org": {
                     "patientAccessList": {
-                        "pageInfo": {
-                            "endCursor": None
-                        },
-                        "patientAccess": [
-                            test_patient2
-                        ]
+                        "pageInfo": {"endCursor": None},
+                        "patientAccess": [test_patient2],
                     }
                 }
-            }
+            },
         ]
 
         patients = get_all_patients(client=self.mock_client)
@@ -563,9 +524,9 @@ class TestPatient(TestCase):
                             "disabled": False,
                             "disabled_at": None,
                             "updated_at": 1646685485.9403558,
-                            "id": "d1"
+                            "id": "d1",
                         }
-                    ]
+                    ],
                 },
                 {
                     "id": "p2",
@@ -580,10 +541,10 @@ class TestPatient(TestCase):
                             "disabled": False,
                             "disabled_at": None,
                             "updated_at": 1646685485.9403558,
-                            "id": "d1"
+                            "id": "d1",
                         }
-                    ]
-                }
+                    ],
+                },
             ],
             patients.to_list(),
         )
@@ -602,10 +563,7 @@ class TestDevice(TestCase):
         """
         self.maxDiff = None
         self.mock_client = GraphClient(
-            Config(
-                client_key_id='test',
-                client_access_key='config'
-            )
+            Config(client_key_id="test", client_access_key="config")
         )
 
     def test_attributes(self):
@@ -640,8 +598,7 @@ class TestDevice(TestCase):
             device_type_id="dt1",
         )
         self.assertEqual(
-            'Device(id="1", name="Percept", patient_id="p1")',
-            repr(test_device)
+            'Device(id="1", name="Percept", patient_id="p1")', repr(test_device)
         )
 
     def test_normalize_id(self):
@@ -651,12 +608,12 @@ class TestDevice(TestCase):
         """
         self.assertEqual(
             "d4b1c627bd464fe0a5ed940cc8e8e485",
-            Device.normalize_id("device-d4b1c627bd464fe0a5ed940cc8e8e485")
+            Device.normalize_id("device-d4b1c627bd464fe0a5ed940cc8e8e485"),
         )
 
         self.assertEqual(
             "d4b1c627bd464fe0a5ed940cc8e8e485",
-            Device.normalize_id("d4b1c627bd464fe0a5ed940cc8e8e485")
+            Device.normalize_id("d4b1c627bd464fe0a5ed940cc8e8e485"),
         )
 
     def test_denormalize_id(self):
@@ -666,36 +623,23 @@ class TestDevice(TestCase):
         """
         self.assertEqual(
             "patient-d4b1c627bd4,device-d4b1c627bd46",
-            Device.denormalize_id(
-                "patient-d4b1c627bd4",
-                "device-d4b1c627bd46"
-            )
+            Device.denormalize_id("patient-d4b1c627bd4", "device-d4b1c627bd46"),
         )
 
         self.assertEqual(
             "patient-d4b1c627bd4,device-d4b1c627bd46",
-            Device.denormalize_id(
-                "patient-d4b1c627bd4",
-                "d4b1c627bd46"
-            )
+            Device.denormalize_id("patient-d4b1c627bd4", "d4b1c627bd46"),
         )
 
         self.assertEqual(
             "patient-d4b1c627bd4,device-d4b1c627bd46",
-            Device.denormalize_id(
-                "d4b1c627bd4",
-                "device-d4b1c627bd46"
-            )
+            Device.denormalize_id("d4b1c627bd4", "device-d4b1c627bd46"),
         )
 
         self.assertEqual(
             "patient-d4b1c627bd4,device-d4b1c627bd46",
-            Device.denormalize_id(
-                "d4b1c627bd4",
-                "d4b1c627bd46"
-            )
+            Device.denormalize_id("d4b1c627bd4", "d4b1c627bd46"),
         )
-
 
     def test_get_device(self):
         """
@@ -714,17 +658,10 @@ class TestDevice(TestCase):
             id="p1",
             created_at=1629300943.9179766,
             name="patient1",
-            devices=DeviceSet(
-                [
-                    test_device
-                ]
-            )
+            devices=DeviceSet([test_device]),
         )
 
-        act_device = get_device(
-            patient=test_patient,
-            device_id="device-1"
-        )
+        act_device = get_device(patient=test_patient, device_id="device-1")
         self.assertEqual(test_device.to_dict(), act_device.to_dict())
 
     def test_get_patient_devices(self):
@@ -752,23 +689,14 @@ class TestDevice(TestCase):
             id="p1",
             created_at=1629300943.9179766,
             name="patient1",
-            devices=DeviceSet(
-                [
-                    test_device_1,
-                    test_device_2
-                ]
-            )
+            devices=DeviceSet([test_device_1, test_device_2]),
         )
 
         act_devices = get_patient_devices(
             patient=test_patient,
         )
         self.assertEqual(
-            [
-                test_device_1.to_dict(),
-                test_device_2.to_dict()
-            ],
-            act_devices.to_list()
+            [test_device_1.to_dict(), test_device_2.to_dict()], act_devices.to_list()
         )
 
     def test_get_all_devices(self):
@@ -788,7 +716,7 @@ class TestDevice(TestCase):
             id="p1",
             created_at=1629300943.9179766,
             name="patient1",
-            devices=DeviceSet([test_device_1])
+            devices=DeviceSet([test_device_1]),
         )
 
         test_device_2 = Device(
@@ -803,16 +731,12 @@ class TestDevice(TestCase):
             id="p2",
             created_at=1629300943.9179766,
             name="patient2",
-            devices=DeviceSet([test_device_2])
+            devices=DeviceSet([test_device_2]),
         )
 
         patients = PatientSet([test_patient_1, test_patient_2])
 
         act_devices = get_all_devices(patients=patients)
         self.assertEqual(
-            [
-                test_device_1.to_dict(),
-                test_device_2.to_dict()
-            ],
-            act_devices.to_list()
+            [test_device_1.to_dict(), test_device_2.to_dict()], act_devices.to_list()
         )

--- a/tests/resources/test_project.py
+++ b/tests/resources/test_project.py
@@ -8,16 +8,16 @@ from runeq.config import Config
 from runeq.resources.client import GraphClient
 from runeq.resources.project import (
     Cohort,
+    CohortPatientMetadata,
     CohortSet,
+    Metric,
+    MetricSet,
     Project,
     ProjectPatientMetadata,
-    CohortPatientMetadata,
-    MetricSet,
-    Metric,
-    get_project,
-    get_projects,
-    get_project_patients,
     get_cohort_patients,
+    get_project,
+    get_project_patients,
+    get_projects,
 )
 
 
@@ -26,6 +26,7 @@ class TestProject(TestCase):
     Unit tests for the Project class.
 
     """
+
     def setUp(self):
         """
         Set up mock graph client for testing.
@@ -98,7 +99,7 @@ class TestProject(TestCase):
                 "created_at": 1667225389.222881,
                 "updated_at": 1667225389.084547,
                 "created_by": "Computer wizard",
-                "updated_by": "Computer wizard"
+                "updated_by": "Computer wizard",
             }
         ]
         self.mock_client.execute = mock.Mock()
@@ -113,9 +114,7 @@ class TestProject(TestCase):
             "started_at": 1630515986.9949625,
             "status": "ACTIVE",
             "type": "SANDBOX",
-            "cohortList": {
-                "cohorts": example_cohorts
-            }
+            "cohortList": {"cohorts": example_cohorts},
         }
 
         expected_project = {
@@ -159,7 +158,7 @@ class TestProject(TestCase):
                 "updated_at": 1630515986.9949625,
                 "type": "SANDBOX",
                 "updated_by": "user-id-1",
-                "cohorts": []
+                "cohorts": [],
             },
             {
                 "id": "proj2-id",
@@ -172,7 +171,7 @@ class TestProject(TestCase):
                 "status": "ACTIVE",
                 "type": "SANDBOX",
                 "updated_by": "user-id-1",
-                "cohorts": []
+                "cohorts": [],
             },
             {
                 "id": "proj3-id",
@@ -185,7 +184,7 @@ class TestProject(TestCase):
                 "status": "ACTIVE",
                 "type": "SANDBOX",
                 "updated_by": "user-id-1",
-                "cohorts": []
+                "cohorts": [],
             },
         ]
         self.mock_client.execute.return_value = {
@@ -204,9 +203,7 @@ class TestProject(TestCase):
                             "updated_at": 1630515986.9949625,
                             "type": "SANDBOX",
                             "updated_by": "user-id-1",
-                            "cohortList": {
-                                "cohorts": []
-                            }
+                            "cohortList": {"cohorts": []},
                         },
                         {
                             "id": "proj2-id",
@@ -219,9 +216,7 @@ class TestProject(TestCase):
                             "status": "ACTIVE",
                             "type": "SANDBOX",
                             "updated_by": "user-id-1",
-                            "cohortList": {
-                                "cohorts": []
-                            }
+                            "cohortList": {"cohorts": []},
                         },
                         {
                             "id": "proj3-id",
@@ -234,9 +229,7 @@ class TestProject(TestCase):
                             "status": "ACTIVE",
                             "type": "SANDBOX",
                             "updated_by": "user-id-1",
-                            "cohortList": {
-                                "cohorts": []
-                            }
+                            "cohortList": {"cohorts": []},
                         },
                     ],
                     "pageInfo": {"endCursor": None},
@@ -269,7 +262,7 @@ class TestProject(TestCase):
             "type": "SANDBOX",
             "created_by": "user-id-1",
             "updated_by": "user-id-1",
-            "cohorts": []
+            "cohorts": [],
         }
         project_2 = {
             "id": "proj2-id",
@@ -282,7 +275,7 @@ class TestProject(TestCase):
             "status": "ACTIVE",
             "type": "SANDBOX",
             "updated_by": "user-id-1",
-            "cohorts": []
+            "cohorts": [],
         }
         project_3 = {
             "id": "proj3-id",
@@ -295,7 +288,7 @@ class TestProject(TestCase):
             "status": "ACTIVE",
             "type": "SANDBOX",
             "updated_by": "user-id-1",
-            "cohorts": []
+            "cohorts": [],
         }
 
         self.mock_client.execute = mock.Mock()
@@ -317,9 +310,7 @@ class TestProject(TestCase):
                                 "type": "SANDBOX",
                                 "created_by": "user-id-1",
                                 "updated_by": "user-id-1",
-                                "cohortList": {
-                                    "cohorts": []
-                                }
+                                "cohortList": {"cohorts": []},
                             },
                             {
                                 "id": "proj2-id",
@@ -332,10 +323,8 @@ class TestProject(TestCase):
                                 "status": "ACTIVE",
                                 "type": "SANDBOX",
                                 "updated_by": "user-id-1",
-                                "cohortList": {
-                                    "cohorts": []
-                                }
-                            }
+                                "cohortList": {"cohorts": []},
+                            },
                         ],
                         "pageInfo": {"endCursor": "test_check_next"},
                     },
@@ -357,9 +346,7 @@ class TestProject(TestCase):
                                 "status": "ACTIVE",
                                 "type": "SANDBOX",
                                 "updated_by": "user-id-1",
-                                "cohortList": {
-                                    "cohorts": []
-                                }
+                                "cohortList": {"cohorts": []},
                             }
                         ],
                         "pageInfo": {"endCursor": None},
@@ -389,7 +376,7 @@ class TestProject(TestCase):
                     time_interval="FOURTEEN_DAYS",
                     created_at=1673467628.837126,
                     updated_at=1673467628.837126,
-                    id="1bfcf11f-8d5c-4714-b774-6b47e03c5900"
+                    id="1bfcf11f-8d5c-4714-b774-6b47e03c5900",
                 ),
             ]
         )
@@ -446,7 +433,7 @@ class TestProject(TestCase):
                     time_interval="FOURTEEN_DAYS",
                     created_at=1673467628.837126,
                     updated_at=1673467628.837126,
-                    id="1bfcf11f-8d5c-4714-b774-6b47e03c5900"
+                    id="1bfcf11f-8d5c-4714-b774-6b47e03c5900",
                 ),
             ]
         )
@@ -519,9 +506,7 @@ class TestProject(TestCase):
                 "projectPatientList": {
                     "projectPatients": [
                         {
-                            "patient": {
-                                "id": "patient-1"
-                            },
+                            "patient": {"id": "patient-1"},
                             "metricList": {
                                 "metrics": [
                                     {
@@ -542,9 +527,7 @@ class TestProject(TestCase):
                             "updated_by": "user 2",
                         },
                         {
-                            "patient": {
-                                "id": "patient-2"
-                            },
+                            "patient": {"id": "patient-2"},
                             "metricList": {
                                 "metrics": [
                                     {
@@ -565,13 +548,10 @@ class TestProject(TestCase):
                             "updated_by": "user 3",
                         },
                     ],
-                    "pageInfo": {
-                        "codeNameEndCursor": None
-                    },
+                    "pageInfo": {"codeNameEndCursor": None},
                 }
             }
         }
-
 
         project_patients = get_project_patients(
             client=self.mock_client, project_id="test-project-1"
@@ -599,7 +579,7 @@ class TestProject(TestCase):
                         "type": "LAST_UPLOAD",
                         "data_type": "APPLEWATCH_TREMOR",
                         "value": 1648235452.965804,
-                        "time_interval": "FOURTEEN_DAYS"
+                        "time_interval": "FOURTEEN_DAYS",
                     },
                 ],
                 "code_name": "code name 1",
@@ -618,7 +598,7 @@ class TestProject(TestCase):
                         "type": "LAST_UPLOAD",
                         "data_type": "APPLEWATCH_TREMOR",
                         "value": 1648235452.965804,
-                        "time_interval": "FOURTEEN_DAYS"
+                        "time_interval": "FOURTEEN_DAYS",
                     },
                 ],
                 "code_name": "code name 2",
@@ -635,9 +615,7 @@ class TestProject(TestCase):
                     "projectPatientList": {
                         "projectPatients": [
                             {
-                                "patient": {
-                                    "id": "patient-1"
-                                },
+                                "patient": {"id": "patient-1"},
                                 "metricList": {
                                     "metrics": [
                                         {
@@ -647,7 +625,7 @@ class TestProject(TestCase):
                                             "type": "LAST_UPLOAD",
                                             "data_type": "APPLEWATCH_TREMOR",
                                             "value": 1648235452.965804,
-                                            "time_interval": "FOURTEEN_DAYS"
+                                            "time_interval": "FOURTEEN_DAYS",
                                         },
                                     ]
                                 },
@@ -658,9 +636,7 @@ class TestProject(TestCase):
                                 "updated_by": "user 2",
                             },
                         ],
-                        "pageInfo": {
-                            "codeNameEndCursor": "code name 1"
-                        },
+                        "pageInfo": {"codeNameEndCursor": "code name 1"},
                     }
                 }
             },
@@ -669,9 +645,7 @@ class TestProject(TestCase):
                     "projectPatientList": {
                         "projectPatients": [
                             {
-                                "patient": {
-                                    "id": "patient-2"
-                                },
+                                "patient": {"id": "patient-2"},
                                 "metricList": {
                                     "metrics": [
                                         {
@@ -681,7 +655,7 @@ class TestProject(TestCase):
                                             "type": "LAST_UPLOAD",
                                             "data_type": "APPLEWATCH_TREMOR",
                                             "value": 1648235452.965804,
-                                            "time_interval": "FOURTEEN_DAYS"
+                                            "time_interval": "FOURTEEN_DAYS",
                                         },
                                     ]
                                 },
@@ -692,12 +666,11 @@ class TestProject(TestCase):
                                 "updated_by": "user 3",
                             },
                         ],
-                        "pageInfo": {
-                            "codeNameEndCursor": None
-                        },
+                        "pageInfo": {"codeNameEndCursor": None},
                     }
                 }
-            }]
+            },
+        ]
 
         project_patients = get_project_patients(
             client=self.mock_client, project_id="test-project-1"
@@ -725,7 +698,7 @@ class TestProject(TestCase):
                         "type": "LAST_UPLOAD",
                         "data_type": "APPLEWATCH_TREMOR",
                         "value": 1648235452.965804,
-                        "time_interval": "FOURTEEN_DAYS"
+                        "time_interval": "FOURTEEN_DAYS",
                     },
                 ],
                 "code_name": "code name 1",
@@ -744,7 +717,7 @@ class TestProject(TestCase):
                         "type": "LAST_UPLOAD",
                         "data_type": "APPLEWATCH_TREMOR",
                         "value": 1648235452.965804,
-                        "time_interval": "FOURTEEN_DAYS"
+                        "time_interval": "FOURTEEN_DAYS",
                     },
                 ],
                 "code_name": "code name 2",
@@ -760,9 +733,7 @@ class TestProject(TestCase):
                 "cohortPatientList": {
                     "cohortPatients": [
                         {
-                            "patient": {
-                                "id": "patient-1"
-                            },
+                            "patient": {"id": "patient-1"},
                             "metricList": {
                                 "metrics": [
                                     {
@@ -772,7 +743,7 @@ class TestProject(TestCase):
                                         "type": "LAST_UPLOAD",
                                         "data_type": "APPLEWATCH_TREMOR",
                                         "value": 1648235452.965804,
-                                        "time_interval": "FOURTEEN_DAYS"
+                                        "time_interval": "FOURTEEN_DAYS",
                                     },
                                 ]
                             },
@@ -783,9 +754,7 @@ class TestProject(TestCase):
                             "updated_by": "user 2",
                         },
                         {
-                            "patient": {
-                                "id": "patient-2"
-                            },
+                            "patient": {"id": "patient-2"},
                             "metricList": {
                                 "metrics": [
                                     {
@@ -795,7 +764,7 @@ class TestProject(TestCase):
                                         "type": "LAST_UPLOAD",
                                         "data_type": "APPLEWATCH_TREMOR",
                                         "value": 1648235452.965804,
-                                        "time_interval": "FOURTEEN_DAYS"
+                                        "time_interval": "FOURTEEN_DAYS",
                                     },
                                 ]
                             },
@@ -806,13 +775,10 @@ class TestProject(TestCase):
                             "updated_by": "user 3",
                         },
                     ],
-                    "pageInfo": {
-                        "codeNameEndCursor": None
-                    },
+                    "pageInfo": {"codeNameEndCursor": None},
                 }
             }
         }
-
 
         cohort_patients = get_cohort_patients(
             client=self.mock_client, cohort_id="test-cohort-1"
@@ -840,7 +806,7 @@ class TestProject(TestCase):
                         "type": "LAST_UPLOAD",
                         "data_type": "APPLEWATCH_TREMOR",
                         "value": 1648235452.965804,
-                        "time_interval": "FOURTEEN_DAYS"
+                        "time_interval": "FOURTEEN_DAYS",
                     },
                 ],
                 "code_name": "code name 1",
@@ -859,7 +825,7 @@ class TestProject(TestCase):
                         "type": "LAST_UPLOAD",
                         "data_type": "APPLEWATCH_TREMOR",
                         "value": 1648235452.965804,
-                        "time_interval": "FOURTEEN_DAYS"
+                        "time_interval": "FOURTEEN_DAYS",
                     },
                 ],
                 "code_name": "code name 2",
@@ -876,9 +842,7 @@ class TestProject(TestCase):
                     "cohortPatientList": {
                         "cohortPatients": [
                             {
-                                "patient": {
-                                    "id": "patient-1"
-                                },
+                                "patient": {"id": "patient-1"},
                                 "metricList": {
                                     "metrics": [
                                         {
@@ -888,7 +852,7 @@ class TestProject(TestCase):
                                             "type": "LAST_UPLOAD",
                                             "data_type": "APPLEWATCH_TREMOR",
                                             "value": 1648235452.965804,
-                                            "time_interval": "FOURTEEN_DAYS"
+                                            "time_interval": "FOURTEEN_DAYS",
                                         },
                                     ]
                                 },
@@ -899,9 +863,7 @@ class TestProject(TestCase):
                                 "updated_by": "user 2",
                             },
                         ],
-                        "pageInfo": {
-                            "codeNameEndCursor": "code name 1"
-                        },
+                        "pageInfo": {"codeNameEndCursor": "code name 1"},
                     }
                 }
             },
@@ -910,9 +872,7 @@ class TestProject(TestCase):
                     "cohortPatientList": {
                         "cohortPatients": [
                             {
-                                "patient": {
-                                    "id": "patient-2"
-                                },
+                                "patient": {"id": "patient-2"},
                                 "metricList": {
                                     "metrics": [
                                         {
@@ -922,7 +882,7 @@ class TestProject(TestCase):
                                             "type": "LAST_UPLOAD",
                                             "data_type": "APPLEWATCH_TREMOR",
                                             "value": 1648235452.965804,
-                                            "time_interval": "FOURTEEN_DAYS"
+                                            "time_interval": "FOURTEEN_DAYS",
                                         },
                                     ]
                                 },
@@ -933,12 +893,10 @@ class TestProject(TestCase):
                                 "updated_by": "user 3",
                             },
                         ],
-                        "pageInfo": {
-                            "codeNameEndCursor": None
-                        },
+                        "pageInfo": {"codeNameEndCursor": None},
                     }
                 }
-            }
+            },
         ]
 
         cohort_patients = get_cohort_patients(

--- a/tests/resources/test_stream.py
+++ b/tests/resources/test_stream.py
@@ -22,10 +22,7 @@ class TestStreamData(TestCase):
 
         """
         self.stream_client = StreamClient(
-            Config(
-                client_key_id='test',
-                client_access_key='config'
-            )
+            Config(client_key_id="test", client_access_key="config")
         )
         self.maxDiff = None
 
@@ -48,9 +45,7 @@ class TestStreamData(TestCase):
         # Mock a paginated response
         mock_response1 = mock.Mock()
         mock_response1.ok = True
-        mock_response1.headers = {
-            "X-Rune-Next-Page-Token": "foobar"
-        }
+        mock_response1.headers = {"X-Rune-Next-Page-Token": "foobar"}
         mock_response1.text = expected_data
 
         mock_response2 = mock.Mock()
@@ -58,12 +53,12 @@ class TestStreamData(TestCase):
         mock_response2.headers = {}
         mock_response2.text = expected_data
 
-        mock_requests.get.side_effect = [
-            mock_response1,
-            mock_response2
-        ]
+        mock_requests.get.side_effect = [mock_response1, mock_response2]
 
-        stream = get_stream_data('test_stream_id', client=self.stream_client,)
+        stream = get_stream_data(
+            "test_stream_id",
+            client=self.stream_client,
+        )
 
         expected = [expected_data, expected_data]
         actual = list(stream)
@@ -118,14 +113,14 @@ class TestStreamData(TestCase):
                 "timezone": None,
                 "timezone_name": "America/Los_Angeles",
                 "translate_enums": False,
-            }
+            },
         )
 
         mock_requests.get.reset_mock()
 
         # Test timestamp conversion
         data = get_stream_data(
-            'stream2',
+            "stream2",
             start_time=datetime(2023, 8, 1, tzinfo=timezone.utc),
             end_time=datetime(2023, 8, 11, 10, 26, 45, 1, tzinfo=timezone.utc),
             client=self.stream_client,
@@ -171,7 +166,7 @@ class TestStreamData(TestCase):
                     0.026072751730680466,
                     0.027338741347193718,
                     0.028795091435313225,
-                    0.029819512739777565
+                    0.029819512739777565,
                 ],
                 "measurement_duration_ns": [
                     20000000,
@@ -183,7 +178,7 @@ class TestStreamData(TestCase):
                     20000000,
                     20000000,
                     20000000,
-                    20000000
+                    20000000,
                 ],
                 "time": [
                     "2022-07-28T14:26:45.167568Z",
@@ -195,17 +190,15 @@ class TestStreamData(TestCase):
                     "2022-07-28T14:26:45.36221Z",
                     "2022-07-28T14:26:45.362269Z",
                     "2022-07-28T14:26:45.36234Z",
-                    "2022-07-28T14:26:45.3624Z"
-                ]
-            }
+                    "2022-07-28T14:26:45.3624Z",
+                ],
+            },
         }
 
         # Mock a paginated response
         mock_response1 = mock.Mock()
         mock_response1.ok = True
-        mock_response1.headers = {
-            "X-Rune-Next-Page-Token": "foobar"
-        }
+        mock_response1.headers = {"X-Rune-Next-Page-Token": "foobar"}
         mock_response1.json.return_value = expected_data
 
         mock_response2 = mock.Mock()
@@ -213,13 +206,10 @@ class TestStreamData(TestCase):
         mock_response2.headers = {}
         mock_response2.json.return_value = expected_data
 
-        mock_requests.get.side_effect = [
-            mock_response1,
-            mock_response2
-        ]
+        mock_requests.get.side_effect = [mock_response1, mock_response2]
 
         stream = get_stream_data(
-            'test_stream_id',
+            "test_stream_id",
             format="json",
             client=self.stream_client,
         )
@@ -247,9 +237,7 @@ class TestStreamData(TestCase):
         # Mock a paginated response
         mock_response1 = mock.Mock()
         mock_response1.ok = True
-        mock_response1.headers = {
-            "X-Rune-Next-Page-Token": "foobar"
-        }
+        mock_response1.headers = {"X-Rune-Next-Page-Token": "foobar"}
         mock_response1.text = expected_data
 
         mock_response2 = mock.Mock()
@@ -257,13 +245,10 @@ class TestStreamData(TestCase):
         mock_response2.headers = {}
         mock_response2.text = expected_data
 
-        mock_requests.get.side_effect = [
-            mock_response1,
-            mock_response2
-        ]
+        mock_requests.get.side_effect = [mock_response1, mock_response2]
 
         availability = get_stream_availability(
-            stream_ids='test_stream_id',
+            stream_ids="test_stream_id",
             start_time=123,
             end_time=345,
             resolution=300,
@@ -293,31 +278,18 @@ class TestStreamData(TestCase):
                     "2022-07-28T14:55:00Z",
                     "2022-07-28T15:00:00Z",
                     "2022-07-28T15:05:00Z",
-                    "2022-07-28T15:10:00Z"
+                    "2022-07-28T15:10:00Z",
                 ],
-                "availability": [
-                    1,
-                    1,
-                    0,
-                    0,
-                    1,
-                    1,
-                    0,
-                    1,
-                    1,
-                    1
-                ]
+                "availability": [1, 1, 0, 0, 1, 1, 0, 1, 1, 1],
             },
             "approx_available_duration_s": 3000,
-            "cardinality": 10
+            "cardinality": 10,
         }
 
         # Mock a paginated response
         mock_response1 = mock.Mock()
         mock_response1.ok = True
-        mock_response1.headers = {
-            "X-Rune-Next-Page-Token": "foobar"
-        }
+        mock_response1.headers = {"X-Rune-Next-Page-Token": "foobar"}
         mock_response1.json.return_value = expected_data
 
         mock_response2 = mock.Mock()
@@ -325,13 +297,10 @@ class TestStreamData(TestCase):
         mock_response2.headers = {}
         mock_response2.json.return_value = expected_data
 
-        mock_requests.get.side_effect = [
-            mock_response1,
-            mock_response2
-        ]
+        mock_requests.get.side_effect = [mock_response1, mock_response2]
 
         availability = get_stream_availability(
-            stream_ids='test_stream_id',
+            stream_ids="test_stream_id",
             start_time=123,
             end_time=345,
             resolution=300,
@@ -362,9 +331,7 @@ class TestStreamData(TestCase):
         # Mock a paginated response
         mock_response1 = mock.Mock()
         mock_response1.ok = True
-        mock_response1.headers = {
-            "X-Rune-Next-Page-Token": "foobar"
-        }
+        mock_response1.headers = {"X-Rune-Next-Page-Token": "foobar"}
         mock_response1.text = expected_data
 
         mock_response2 = mock.Mock()
@@ -372,18 +339,12 @@ class TestStreamData(TestCase):
         mock_response2.headers = {}
         mock_response2.text = expected_data
 
-        mock_requests.get.side_effect = [
-            mock_response1,
-            mock_response2
-        ]
+        mock_requests.get.side_effect = [mock_response1, mock_response2]
 
         # Must include batch_operation when querying >1 stream
-        with self.assertRaisesRegex(
-            ValueError,
-            "batch_operation must be specified"
-        ):
+        with self.assertRaisesRegex(ValueError, "batch_operation must be specified"):
             get_stream_availability(
-                stream_ids=['test_stream_id1', 'test_stream_id2'],
+                stream_ids=["test_stream_id1", "test_stream_id2"],
                 start_time=123,
                 end_time=345,
                 resolution=300,
@@ -392,7 +353,7 @@ class TestStreamData(TestCase):
             ).__next__()
 
         availability = get_stream_availability(
-            stream_ids=['test_stream_id1', 'test_stream_id2'],
+            stream_ids=["test_stream_id1", "test_stream_id2"],
             start_time=123,
             end_time=345,
             resolution=300,

--- a/tests/resources/test_stream_metadata.py
+++ b/tests/resources/test_stream_metadata.py
@@ -9,10 +9,15 @@ from unittest import TestCase, mock
 from runeq.config import Config
 from runeq.resources.client import GraphClient, StreamClient
 from runeq.resources.stream_metadata import (
-    Dimension, StreamMetadata, StreamMetadataSet, StreamType,
-    get_patient_stream_metadata, get_all_stream_types,
-    get_stream_availability_dataframe, get_stream_dataframe,
-    get_stream_metadata
+    Dimension,
+    StreamMetadata,
+    StreamMetadataSet,
+    StreamType,
+    get_all_stream_types,
+    get_patient_stream_metadata,
+    get_stream_availability_dataframe,
+    get_stream_dataframe,
+    get_stream_metadata,
 )
 
 
@@ -54,10 +59,7 @@ class TestStreamType(TestCase):
 
         """
         self.mock_client = GraphClient(
-            Config(
-                client_key_id='test',
-                client_access_key='config'
-            )
+            Config(client_key_id="test", client_access_key="config")
         )
 
     def test_attributes(self):
@@ -69,14 +71,14 @@ class TestStreamType(TestCase):
             id="rotation",
             name="Rotation",
             description="Rotation rate (velocity) sampled in the time-domain.",
-            dimensions=[]
+            dimensions=[],
         )
 
         self.assertEqual("rotation", test_stream_type.id)
         self.assertEqual("Rotation", test_stream_type.name)
         self.assertEqual(
             "Rotation rate (velocity) sampled in the time-domain.",
-            test_stream_type.description
+            test_stream_type.description,
         )
         self.assertEqual([], test_stream_type.dimensions)
 
@@ -89,11 +91,10 @@ class TestStreamType(TestCase):
             id="rotation",
             name="Rotation",
             description="Rotation rate (velocity) sampled in the time-domain.",
-            dimensions=[]
+            dimensions=[],
         )
         self.assertEqual(
-            'StreamType(id="rotation", name="Rotation")',
-            repr(test_stream_type)
+            'StreamType(id="rotation", name="Rotation")', repr(test_stream_type)
         )
 
     def test_get_all_stream_types(self):
@@ -118,7 +119,7 @@ class TestStreamType(TestCase):
                                         "quantity_name": "Time",
                                         "quantity_abbrev": "t",
                                         "unit_name": "Nanoseconds",
-                                        "unit_abbrev": "ns"
+                                        "unit_abbrev": "ns",
                                     },
                                     {
                                         "id": "rotation",
@@ -126,10 +127,10 @@ class TestStreamType(TestCase):
                                         "quantity_name": "Angular Velocity",
                                         "quantity_abbrev": "Rotation",
                                         "unit_name": "Radians per second",
-                                        "unit_abbrev": "rps"
-                                    }
+                                        "unit_abbrev": "rps",
+                                    },
                                 ]
-                            }
+                            },
                         },
                         {
                             "id": "current",
@@ -143,7 +144,7 @@ class TestStreamType(TestCase):
                                         "quantity_name": "Time",
                                         "quantity_abbrev": "t",
                                         "unit_name": "Nanoseconds",
-                                        "unit_abbrev": "ns"
+                                        "unit_abbrev": "ns",
                                     },
                                     {
                                         "id": "current",
@@ -151,11 +152,11 @@ class TestStreamType(TestCase):
                                         "quantity_name": "Current",
                                         "quantity_abbrev": "I",
                                         "unit_name": "Amps",
-                                        "unit_abbrev": "A"
-                                    }
+                                        "unit_abbrev": "A",
+                                    },
                                 ]
-                            }
-                        }
+                            },
+                        },
                     ]
                 }
             }
@@ -176,7 +177,7 @@ class TestStreamType(TestCase):
                             "quantity_name": "Time",
                             "quantity_abbrev": "t",
                             "unit_name": "Nanoseconds",
-                            "unit_abbrev": "ns"
+                            "unit_abbrev": "ns",
                         },
                         {
                             "id": "rotation",
@@ -184,9 +185,9 @@ class TestStreamType(TestCase):
                             "quantity_name": "Angular Velocity",
                             "quantity_abbrev": "Rotation",
                             "unit_name": "Radians per second",
-                            "unit_abbrev": "rps"
-                        }
-                    ]
+                            "unit_abbrev": "rps",
+                        },
+                    ],
                 },
                 {
                     "id": "current",
@@ -199,7 +200,7 @@ class TestStreamType(TestCase):
                             "quantity_name": "Time",
                             "quantity_abbrev": "t",
                             "unit_name": "Nanoseconds",
-                            "unit_abbrev": "ns"
+                            "unit_abbrev": "ns",
                         },
                         {
                             "id": "current",
@@ -207,10 +208,10 @@ class TestStreamType(TestCase):
                             "quantity_name": "Current",
                             "quantity_abbrev": "I",
                             "unit_name": "Amps",
-                            "unit_abbrev": "A"
-                        }
-                    ]
-                }
+                            "unit_abbrev": "A",
+                        },
+                    ],
+                },
             ],
             stream_types.to_list(),
         )
@@ -228,17 +229,11 @@ class TestStreamMetadata(TestCase):
 
         """
         self.mock_graph_client = GraphClient(
-            Config(
-                client_key_id='test',
-                client_access_key='config'
-            )
+            Config(client_key_id="test", client_access_key="config")
         )
 
         self.mock_stream_client = StreamClient(
-            Config(
-                client_key_id='test',
-                client_access_key='config'
-            )
+            Config(client_key_id="test", client_access_key="config")
         )
 
         self.maxDiff = None
@@ -264,7 +259,7 @@ class TestStreamMetadata(TestCase):
             stream_type=test_stream_type,
             min_time=1648231560,
             max_time=1648234860,
-            parameters={"category": "vitals"}
+            parameters={"category": "vitals"},
         )
 
         self.assertEqual("s1", test_stream.id)
@@ -291,12 +286,9 @@ class TestStreamMetadata(TestCase):
             stream_type=None,
             min_time=1648231560,
             max_time=1648234860,
-            parameters={"category": "vitals"}
+            parameters={"category": "vitals"},
         )
-        self.assertEqual(
-            'StreamMetadata(id="s1")',
-            repr(test_stream)
-        )
+        self.assertEqual('StreamMetadata(id="s1")', repr(test_stream))
 
     def test_get_stream_metadata(self):
         """
@@ -307,9 +299,7 @@ class TestStreamMetadata(TestCase):
         self.mock_graph_client.execute.side_effect = [
             {
                 "streamListByIds": {
-                    "pageInfo": {
-                        "endCursor": None
-                    },
+                    "pageInfo": {"endCursor": None},
                     "streams": [
                         {
                             "id": "s1",
@@ -329,7 +319,7 @@ class TestStreamMetadata(TestCase):
                                             "quantity_name": "Time",
                                             "quantity_abbrev": "t",
                                             "unit_name": "Seconds",
-                                            "unit_abbrev": "s"
+                                            "unit_abbrev": "s",
                                         },
                                         {
                                             "id": "duration",
@@ -337,13 +327,13 @@ class TestStreamMetadata(TestCase):
                                             "quantity_name": "Duration",
                                             "quantity_abbrev": "Duration",
                                             "unit_name": "Seconds",
-                                            "unit_abbrev": "s"
-                                        }
+                                            "unit_abbrev": "s",
+                                        },
                                     ]
-                                }
+                                },
                             },
                             "min_time": 1648231560,
-                            "max_time": 1648234860
+                            "max_time": 1648234860,
                         },
                         {
                             "id": "s2",
@@ -363,7 +353,7 @@ class TestStreamMetadata(TestCase):
                                             "quantity_name": "Time",
                                             "quantity_abbrev": "t",
                                             "unit_name": "Seconds",
-                                            "unit_abbrev": "s"
+                                            "unit_abbrev": "s",
                                         },
                                         {
                                             "id": "duration",
@@ -371,22 +361,21 @@ class TestStreamMetadata(TestCase):
                                             "quantity_name": "Duration",
                                             "quantity_abbrev": "Duration",
                                             "unit_name": "Seconds",
-                                            "unit_abbrev": "s"
-                                        }
+                                            "unit_abbrev": "s",
+                                        },
                                     ]
-                                }
+                                },
                             },
                             "min_time": 1648231560,
-                            "max_time": 1648234860
-                        }
-                    ]
+                            "max_time": 1648234860,
+                        },
+                    ],
                 }
             }
         ]
 
         streams = get_stream_metadata(
-            stream_ids=["s1", "s2"],
-            client=self.mock_graph_client
+            stream_ids=["s1", "s2"], client=self.mock_graph_client
         )
 
         self.assertEqual(
@@ -406,7 +395,7 @@ class TestStreamMetadata(TestCase):
                                 "unit_name": "Seconds",
                                 "quantity_abbrev": "t",
                                 "unit_abbrev": "s",
-                                "id": "time"
+                                "id": "time",
                             },
                             {
                                 "data_type": "sfloat",
@@ -414,15 +403,15 @@ class TestStreamMetadata(TestCase):
                                 "unit_name": "Seconds",
                                 "quantity_abbrev": "Duration",
                                 "unit_abbrev": "s",
-                                "id": "duration"
-                            }
+                                "id": "duration",
+                            },
                         ],
-                        "id": "duration"
+                        "id": "duration",
                     },
-                    'parameters': {},
+                    "parameters": {},
                     "min_time": 1648231560,
                     "max_time": 1648234860,
-                    "id": "s1"
+                    "id": "s1",
                 },
                 {
                     "created_at": 1655226140.501,
@@ -439,7 +428,7 @@ class TestStreamMetadata(TestCase):
                                 "unit_name": "Seconds",
                                 "quantity_abbrev": "t",
                                 "unit_abbrev": "s",
-                                "id": "time"
+                                "id": "time",
                             },
                             {
                                 "data_type": "sfloat",
@@ -447,16 +436,16 @@ class TestStreamMetadata(TestCase):
                                 "unit_name": "Seconds",
                                 "quantity_abbrev": "Duration",
                                 "unit_abbrev": "s",
-                                "id": "duration"
-                            }
+                                "id": "duration",
+                            },
                         ],
-                        "id": "duration"
+                        "id": "duration",
                     },
-                    'parameters': {},
+                    "parameters": {},
                     "min_time": 1648231560,
                     "max_time": 1648234860,
-                    "id": "s2"
-                }
+                    "id": "s2",
+                },
             ],
             streams.to_list(),
         )
@@ -486,7 +475,7 @@ class TestStreamMetadata(TestCase):
                             "quantity_name": "Time",
                             "quantity_abbrev": "t",
                             "unit_name": "Seconds",
-                            "unit_abbrev": "s"
+                            "unit_abbrev": "s",
                         },
                         {
                             "id": "duration",
@@ -494,13 +483,13 @@ class TestStreamMetadata(TestCase):
                             "quantity_name": "Duration",
                             "quantity_abbrev": "Duration",
                             "unit_name": "Seconds",
-                            "unit_abbrev": "s"
-                        }
+                            "unit_abbrev": "s",
+                        },
                     ]
-                }
+                },
             },
             "min_time": 1648231560,
-            "max_time": 1648234860
+            "max_time": 1648234860,
         }
 
         first_hundred_streams = []
@@ -518,25 +507,20 @@ class TestStreamMetadata(TestCase):
         self.mock_graph_client.execute.side_effect = [
             {
                 "streamListByIds": {
-                    "pageInfo": {
-                        "endCursor": None
-                    },
-                    "streams": first_hundred_streams
+                    "pageInfo": {"endCursor": None},
+                    "streams": first_hundred_streams,
                 }
             },
             {
                 "streamListByIds": {
-                    "pageInfo": {
-                        "endCursor": None
-                    },
-                    "streams": next_fifty_streams
+                    "pageInfo": {"endCursor": None},
+                    "streams": next_fifty_streams,
                 }
             },
         ]
 
         streams = get_stream_metadata(
-            stream_ids=[str(i) for i in range(150)],
-            client=self.mock_graph_client
+            stream_ids=[str(i) for i in range(150)], client=self.mock_graph_client
         )
 
         self.assertEqual(150, len(streams.to_list()))
@@ -550,12 +534,9 @@ class TestStreamMetadata(TestCase):
         get_patient.side_effect = Exception("NotFoundError")
 
         with self.assertRaises(Exception) as context:
-            get_patient_stream_metadata(
-                patient_id='foo',
-                client=self.mock_graph_client
-            )
+            get_patient_stream_metadata(patient_id="foo", client=self.mock_graph_client)
 
-        self.assertTrue('NotFoundError' in str(context.exception))
+        self.assertTrue("NotFoundError" in str(context.exception))
 
     @mock.patch("runeq.resources.stream_metadata.get_patient")
     def test_get_patient_streams_basic(self, _):
@@ -567,9 +548,7 @@ class TestStreamMetadata(TestCase):
         self.mock_graph_client.execute.side_effect = [
             {
                 "streamList": {
-                    "pageInfo": {
-                        "endCursor": None
-                    },
+                    "pageInfo": {"endCursor": None},
                     "streams": [
                         {
                             "id": "s1",
@@ -589,7 +568,7 @@ class TestStreamMetadata(TestCase):
                                             "quantity_name": "Time",
                                             "quantity_abbrev": "t",
                                             "unit_name": "Seconds",
-                                            "unit_abbrev": "s"
+                                            "unit_abbrev": "s",
                                         },
                                         {
                                             "id": "duration",
@@ -597,23 +576,17 @@ class TestStreamMetadata(TestCase):
                                             "quantity_name": "Duration",
                                             "quantity_abbrev": "Duration",
                                             "unit_name": "Seconds",
-                                            "unit_abbrev": "s"
-                                        }
+                                            "unit_abbrev": "s",
+                                        },
                                     ]
-                                }
+                                },
                             },
                             "parameters": [
-                                {
-                                    "key": "category",
-                                    "value": "motion"
-                                },
-                                {
-                                    "key": "measurement",
-                                    "value": "walking"
-                                }
+                                {"key": "category", "value": "motion"},
+                                {"key": "measurement", "value": "walking"},
                             ],
                             "min_time": 1648231560,
-                            "max_time": 1648234860
+                            "max_time": 1648234860,
                         },
                         {
                             "id": "s2",
@@ -633,7 +606,7 @@ class TestStreamMetadata(TestCase):
                                             "quantity_name": "Time",
                                             "quantity_abbrev": "t",
                                             "unit_name": "Seconds",
-                                            "unit_abbrev": "s"
+                                            "unit_abbrev": "s",
                                         },
                                         {
                                             "id": "duration",
@@ -641,22 +614,21 @@ class TestStreamMetadata(TestCase):
                                             "quantity_name": "Duration",
                                             "quantity_abbrev": "Duration",
                                             "unit_name": "Seconds",
-                                            "unit_abbrev": "s"
-                                        }
+                                            "unit_abbrev": "s",
+                                        },
                                     ]
-                                }
+                                },
                             },
                             "min_time": 1648231560,
-                            "max_time": 1648234860
-                        }
-                    ]
+                            "max_time": 1648234860,
+                        },
+                    ],
                 }
             }
         ]
 
         streams = get_patient_stream_metadata(
-            patient_id="p1",
-            client=self.mock_graph_client
+            patient_id="p1", client=self.mock_graph_client
         )
 
         self.assertEqual(
@@ -676,7 +648,7 @@ class TestStreamMetadata(TestCase):
                                 "unit_name": "Seconds",
                                 "quantity_abbrev": "t",
                                 "unit_abbrev": "s",
-                                "id": "time"
+                                "id": "time",
                             },
                             {
                                 "data_type": "sfloat",
@@ -684,20 +656,17 @@ class TestStreamMetadata(TestCase):
                                 "unit_name": "Seconds",
                                 "quantity_abbrev": "Duration",
                                 "unit_abbrev": "s",
-                                "id": "duration"
-                            }
+                                "id": "duration",
+                            },
                         ],
-                        "id": "duration"
+                        "id": "duration",
                     },
                     "category": "motion",
                     "measurement": "walking",
-                    'parameters': {
-                        'category': 'motion',
-                        'measurement': 'walking'
-                    },
+                    "parameters": {"category": "motion", "measurement": "walking"},
                     "min_time": 1648231560,
                     "max_time": 1648234860,
-                    "id": "s1"
+                    "id": "s1",
                 },
                 {
                     "created_at": 1655226140.501,
@@ -714,7 +683,7 @@ class TestStreamMetadata(TestCase):
                                 "unit_name": "Seconds",
                                 "quantity_abbrev": "t",
                                 "unit_abbrev": "s",
-                                "id": "time"
+                                "id": "time",
                             },
                             {
                                 "data_type": "sfloat",
@@ -722,16 +691,16 @@ class TestStreamMetadata(TestCase):
                                 "unit_name": "Seconds",
                                 "quantity_abbrev": "Duration",
                                 "unit_abbrev": "s",
-                                "id": "duration"
-                            }
+                                "id": "duration",
+                            },
                         ],
-                        "id": "duration"
+                        "id": "duration",
                     },
-                    'parameters': {},
+                    "parameters": {},
                     "min_time": 1648231560,
                     "max_time": 1648234860,
-                    "id": "s2"
-                }
+                    "id": "s2",
+                },
             ],
             streams.to_list(),
         )
@@ -747,9 +716,7 @@ class TestStreamMetadata(TestCase):
         self.mock_graph_client.execute.side_effect = [
             {
                 "streamList": {
-                    "pageInfo": {
-                        "endCursor": "test_check_next"
-                    },
+                    "pageInfo": {"endCursor": "test_check_next"},
                     "streams": [
                         {
                             "id": "s1",
@@ -769,7 +736,7 @@ class TestStreamMetadata(TestCase):
                                             "quantity_name": "Time",
                                             "quantity_abbrev": "t",
                                             "unit_name": "Seconds",
-                                            "unit_abbrev": "s"
+                                            "unit_abbrev": "s",
                                         },
                                         {
                                             "id": "duration",
@@ -777,22 +744,20 @@ class TestStreamMetadata(TestCase):
                                             "quantity_name": "Duration",
                                             "quantity_abbrev": "Duration",
                                             "unit_name": "Seconds",
-                                            "unit_abbrev": "s"
-                                        }
+                                            "unit_abbrev": "s",
+                                        },
                                     ]
-                                }
+                                },
                             },
                             "min_time": 1648231560,
-                            "max_time": 1648234860
+                            "max_time": 1648234860,
                         },
-                    ]
+                    ],
                 }
             },
             {
                 "streamList": {
-                    "pageInfo": {
-                        "endCursor": None
-                    },
+                    "pageInfo": {"endCursor": None},
                     "streams": [
                         {
                             "id": "s2",
@@ -812,7 +777,7 @@ class TestStreamMetadata(TestCase):
                                             "quantity_name": "Time",
                                             "quantity_abbrev": "t",
                                             "unit_name": "Seconds",
-                                            "unit_abbrev": "s"
+                                            "unit_abbrev": "s",
                                         },
                                         {
                                             "id": "duration",
@@ -820,22 +785,21 @@ class TestStreamMetadata(TestCase):
                                             "quantity_name": "Duration",
                                             "quantity_abbrev": "Duration",
                                             "unit_name": "Seconds",
-                                            "unit_abbrev": "s"
-                                        }
+                                            "unit_abbrev": "s",
+                                        },
                                     ]
-                                }
+                                },
                             },
                             "min_time": 1648231560,
-                            "max_time": 1648234860
+                            "max_time": 1648234860,
                         }
-                    ]
+                    ],
                 }
-            }
+            },
         ]
 
         streams = get_patient_stream_metadata(
-            patient_id="p1",
-            client=self.mock_graph_client
+            patient_id="p1", client=self.mock_graph_client
         )
 
         self.assertEqual(
@@ -855,7 +819,7 @@ class TestStreamMetadata(TestCase):
                                 "unit_name": "Seconds",
                                 "quantity_abbrev": "t",
                                 "unit_abbrev": "s",
-                                "id": "time"
+                                "id": "time",
                             },
                             {
                                 "data_type": "sfloat",
@@ -863,15 +827,15 @@ class TestStreamMetadata(TestCase):
                                 "unit_name": "Seconds",
                                 "quantity_abbrev": "Duration",
                                 "unit_abbrev": "s",
-                                "id": "duration"
-                            }
+                                "id": "duration",
+                            },
                         ],
-                        "id": "duration"
+                        "id": "duration",
                     },
-                    'parameters': {},
+                    "parameters": {},
                     "min_time": 1648231560,
                     "max_time": 1648234860,
-                    "id": "s1"
+                    "id": "s1",
                 },
                 {
                     "created_at": 1655226140.501,
@@ -888,7 +852,7 @@ class TestStreamMetadata(TestCase):
                                 "unit_name": "Seconds",
                                 "quantity_abbrev": "t",
                                 "unit_abbrev": "s",
-                                "id": "time"
+                                "id": "time",
                             },
                             {
                                 "data_type": "sfloat",
@@ -896,16 +860,16 @@ class TestStreamMetadata(TestCase):
                                 "unit_name": "Seconds",
                                 "quantity_abbrev": "Duration",
                                 "unit_abbrev": "s",
-                                "id": "duration"
-                            }
+                                "id": "duration",
+                            },
                         ],
-                        "id": "duration"
+                        "id": "duration",
                     },
-                    'parameters': {},
+                    "parameters": {},
                     "min_time": 1648231560,
                     "max_time": 1648234860,
-                    "id": "s2"
-                }
+                    "id": "s2",
+                },
             ],
             streams.to_list(),
         )
@@ -927,11 +891,11 @@ class TestStreamMetadata(TestCase):
                         id="acceleration",
                         name="Acceleration",
                         description="Acceleration rate",
-                        dimensions=[]
+                        dimensions=[],
                     ),
                     min_time=10,
                     max_time=100,
-                    parameters={}
+                    parameters={},
                 ),
                 StreamMetadata(
                     id="stream2",
@@ -943,11 +907,11 @@ class TestStreamMetadata(TestCase):
                         id="acceleration",
                         name="Acceleration",
                         description="Acceleration rate",
-                        dimensions=[]
+                        dimensions=[],
                     ),
                     min_time=10,
                     max_time=100,
-                    parameters={}
+                    parameters={},
                 ),
                 StreamMetadata(
                     id="stream3",
@@ -959,26 +923,21 @@ class TestStreamMetadata(TestCase):
                         id="motion",
                         name="Motion",
                         description="Motion movement",
-                        dimensions=[]
+                        dimensions=[],
                     ),
                     min_time=10,
                     max_time=100,
-                    parameters={}
+                    parameters={},
                 ),
             ]
         )
 
-        device_streams = stream_set.filter(
-            patient_id="p1",
-            device_id="d1"
-        )
+        device_streams = stream_set.filter(patient_id="p1", device_id="d1")
         self.assertEqual(2, len(device_streams))
         self.assertIsNotNone(device_streams.get("stream1"))
         self.assertIsNotNone(device_streams.get("stream3"))
 
-        motion_streams = device_streams.filter(
-            stream_type_id="motion"
-        )
+        motion_streams = device_streams.filter(stream_type_id="motion")
         self.assertEqual(1, len(motion_streams))
         self.assertIsNotNone(motion_streams.get("stream3"))
 
@@ -1011,9 +970,7 @@ class TestStreamMetadata(TestCase):
         self.mock_graph_client.execute.side_effect = [
             {
                 "streamListByIds": {
-                    "pageInfo": {
-                        "endCursor": None
-                    },
+                    "pageInfo": {"endCursor": None},
                     "streams": [
                         {
                             "id": "s1",
@@ -1033,7 +990,7 @@ class TestStreamMetadata(TestCase):
                                             "quantity_name": "Time",
                                             "quantity_abbrev": "t",
                                             "unit_name": "Seconds",
-                                            "unit_abbrev": "s"
+                                            "unit_abbrev": "s",
                                         },
                                         {
                                             "id": "duration",
@@ -1041,15 +998,15 @@ class TestStreamMetadata(TestCase):
                                             "quantity_name": "Duration",
                                             "quantity_abbrev": "Duration",
                                             "unit_name": "Seconds",
-                                            "unit_abbrev": "s"
-                                        }
+                                            "unit_abbrev": "s",
+                                        },
                                     ]
-                                }
+                                },
                             },
                             "min_time": 1648231560,
-                            "max_time": 1648234860
+                            "max_time": 1648234860,
                         }
-                    ]
+                    ],
                 }
             }
         ]
@@ -1057,7 +1014,7 @@ class TestStreamMetadata(TestCase):
         stream_df = get_stream_dataframe(
             stream_ids="s1",
             stream_client=self.mock_stream_client,
-            graph_client=self.mock_graph_client
+            graph_client=self.mock_graph_client,
         )
 
         self.assertEqual(
@@ -1069,7 +1026,7 @@ class TestStreamMetadata(TestCase):
                     "3": "2022-07-28T14:26:45.3618588Z",
                     "4": "2022-07-28T14:26:45.3620749Z",
                     "5": "2022-07-28T14:26:45.362149Z",
-                    "6": "2022-07-28T14:26:45.36221Z"
+                    "6": "2022-07-28T14:26:45.36221Z",
                 },
                 "acceleration": {
                     "0": 0.0205251388,
@@ -1078,7 +1035,7 @@ class TestStreamMetadata(TestCase):
                     "3": 0.022172993,
                     "4": 0.0235602502,
                     "5": 0.0248600878,
-                    "6": 0.0260727517
+                    "6": 0.0260727517,
                 },
                 "measurement_duration_ns": {
                     "0": 20000000,
@@ -1087,7 +1044,7 @@ class TestStreamMetadata(TestCase):
                     "3": 20000000,
                     "4": 20000000,
                     "5": 20000000,
-                    "6": 20000000
+                    "6": 20000000,
                 },
                 "algorithm": {
                     "0": "a1",
@@ -1096,7 +1053,7 @@ class TestStreamMetadata(TestCase):
                     "3": "a1",
                     "4": "a1",
                     "5": "a1",
-                    "6": "a1"
+                    "6": "a1",
                 },
                 "device_id": {
                     "0": "d1",
@@ -1105,7 +1062,7 @@ class TestStreamMetadata(TestCase):
                     "3": "d1",
                     "4": "d1",
                     "5": "d1",
-                    "6": "d1"
+                    "6": "d1",
                 },
                 "patient_id": {
                     "0": "p1",
@@ -1114,7 +1071,7 @@ class TestStreamMetadata(TestCase):
                     "3": "p1",
                     "4": "p1",
                     "5": "p1",
-                    "6": "p1"
+                    "6": "p1",
                 },
                 "stream_type_id": {
                     "0": "duration",
@@ -1132,10 +1089,10 @@ class TestStreamMetadata(TestCase):
                     "3": "s1",
                     "4": "s1",
                     "5": "s1",
-                    "6": "s1"
-                }
+                    "6": "s1",
+                },
             },
-            json.loads(stream_df.to_json())
+            json.loads(stream_df.to_json()),
         )
 
     def test_get_stream_dataframe_dicts(self):
@@ -1147,9 +1104,9 @@ class TestStreamMetadata(TestCase):
         self.mock_stream_client.get_data = mock.Mock()
         self.mock_stream_client.get_data.return_value = iter(
             [
-                '''time,event,measurement_duration_ns
+                """time,event,measurement_duration_ns
 1648231560.000000,"{""hello"":""world""}",0
-1648231565.000000,"{""rune"":""labs""}",0'''
+1648231565.000000,"{""rune"":""labs""}",0"""
             ]
         )
 
@@ -1157,9 +1114,7 @@ class TestStreamMetadata(TestCase):
         self.mock_graph_client.execute.side_effect = [
             {
                 "streamListByIds": {
-                    "pageInfo": {
-                        "endCursor": None
-                    },
+                    "pageInfo": {"endCursor": None},
                     "streams": [
                         {
                             "id": "s1",
@@ -1179,23 +1134,23 @@ class TestStreamMetadata(TestCase):
                                             "quantity_name": "Time",
                                             "quantity_abbrev": "t",
                                             "unit_name": "Seconds",
-                                            "unit_abbrev": "s"
+                                            "unit_abbrev": "s",
                                         },
                                         {
-                                            'data_type': 'dict',
-                                            'quantity_name': 'Payload',
-                                            'unit_name': '',
-                                            'quantity_abbrev': 'Payload',
-                                            'unit_abbrev': '',
-                                            'id': 'event'
-                                        }
+                                            "data_type": "dict",
+                                            "quantity_name": "Payload",
+                                            "unit_name": "",
+                                            "quantity_abbrev": "Payload",
+                                            "unit_abbrev": "",
+                                            "id": "event",
+                                        },
                                     ]
-                                }
+                                },
                             },
                             "min_time": 1648231560,
-                            "max_time": 1648231565
+                            "max_time": 1648231565,
                         }
-                    ]
+                    ],
                 }
             }
         ]
@@ -1203,7 +1158,7 @@ class TestStreamMetadata(TestCase):
         stream_df = get_stream_dataframe(
             stream_ids="s1",
             stream_client=self.mock_stream_client,
-            graph_client=self.mock_graph_client
+            graph_client=self.mock_graph_client,
         )
 
         self.assertEqual(
@@ -1212,14 +1167,8 @@ class TestStreamMetadata(TestCase):
                     "0": 1648231560.0,
                     "1": 1648231565.0,
                 },
-                "event": {
-                    "0": {"hello": "world"},
-                    "1": {"rune": "labs"}
-                },
-                "measurement_duration_ns": {
-                    "0": 0,
-                    "1": 0
-                },
+                "event": {"0": {"hello": "world"}, "1": {"rune": "labs"}},
+                "measurement_duration_ns": {"0": 0, "1": 0},
                 "algorithm": {
                     "0": "a1",
                     "1": "a1",
@@ -1239,9 +1188,9 @@ class TestStreamMetadata(TestCase):
                 "stream_id": {
                     "0": "s1",
                     "1": "s1",
-                }
+                },
             },
-            json.loads(stream_df.to_json())
+            json.loads(stream_df.to_json()),
         )
 
     def test_get_multiple_stream_dataframe(self):
@@ -1251,27 +1200,33 @@ class TestStreamMetadata(TestCase):
         """
         self.mock_stream_client.get_data = mock.Mock()
         self.mock_stream_client.get_data.side_effect = [
-            iter(["""time,acceleration,measurement_duration_ns
+            iter(
+                [
+                    """time,acceleration,measurement_duration_ns
 2022-07-28T14:26:45.167568Z,0.014469802379608154,20000000
 2022-07-28T14:26:45.361596Z,0.03278458118438721,20000000
 2022-07-28T14:26:45.361796Z,0.03711885213851929,20000000
 2022-07-28T14:26:45.3618588Z,0.02531599998474121,20000000
-2022-07-28T14:26:45.3620749Z,0.03168576955795288,20000000"""]),
-            iter(["""time,acceleration,measurement_duration_ns
+2022-07-28T14:26:45.3620749Z,0.03168576955795288,20000000"""
+                ]
+            ),
+            iter(
+                [
+                    """time,acceleration,measurement_duration_ns
 2022-07-28T14:26:45.167568Z,0.020525138825178146,20000000
 2022-07-28T14:26:45.361596Z,0.020834974944591522,20000000
 2022-07-28T14:26:45.361796Z,0.021182861179113388,20000000
 2022-07-28T14:26:45.3618588Z,0.022172993049025536,20000000
-2022-07-28T14:26:45.3620749Z,0.02356025017797947,20000000"""])
+2022-07-28T14:26:45.3620749Z,0.02356025017797947,20000000"""
+                ]
+            ),
         ]
 
         self.mock_graph_client.execute = mock.Mock()
         self.mock_graph_client.execute.side_effect = [
             {
                 "streamListByIds": {
-                    "pageInfo": {
-                        "endCursor": "None"
-                    },
+                    "pageInfo": {"endCursor": "None"},
                     "streams": [
                         {
                             "id": "s1",
@@ -1291,7 +1246,7 @@ class TestStreamMetadata(TestCase):
                                             "quantity_name": "Time",
                                             "quantity_abbrev": "t",
                                             "unit_name": "Nanoseconds",
-                                            "unit_abbrev": "ns"
+                                            "unit_abbrev": "ns",
                                         },
                                         {
                                             "id": "acceleration",
@@ -1299,27 +1254,18 @@ class TestStreamMetadata(TestCase):
                                             "quantity_name": "Acceleration",
                                             "quantity_abbrev": "Accel",
                                             "unit_name": "Gs",
-                                            "unit_abbrev": "G"
-                                        }
+                                            "unit_abbrev": "G",
+                                        },
                                     ]
-                                }
+                                },
                             },
                             "parameters": [
-                                {
-                                    "key": "axis",
-                                    "value": "z"
-                                },
-                                {
-                                    "key": "category",
-                                    "value": "motion"
-                                },
-                                {
-                                    "key": "measurement",
-                                    "value": "user"
-                                }
+                                {"key": "axis", "value": "z"},
+                                {"key": "category", "value": "motion"},
+                                {"key": "measurement", "value": "user"},
                             ],
                             "min_time": 1659018405.167568,
-                            "max_time": 1659027683.492028
+                            "max_time": 1659027683.492028,
                         },
                         {
                             "id": "s2",
@@ -1339,7 +1285,7 @@ class TestStreamMetadata(TestCase):
                                             "quantity_name": "Time",
                                             "quantity_abbrev": "t",
                                             "unit_name": "Nanoseconds",
-                                            "unit_abbrev": "ns"
+                                            "unit_abbrev": "ns",
                                         },
                                         {
                                             "id": "acceleration",
@@ -1347,29 +1293,20 @@ class TestStreamMetadata(TestCase):
                                             "quantity_name": "Acceleration",
                                             "quantity_abbrev": "Accel",
                                             "unit_name": "Gs",
-                                            "unit_abbrev": "G"
-                                        }
+                                            "unit_abbrev": "G",
+                                        },
                                     ]
-                                }
+                                },
                             },
                             "parameters": [
-                                {
-                                    "key": "axis",
-                                    "value": "x"
-                                },
-                                {
-                                    "key": "category",
-                                    "value": "motion"
-                                },
-                                {
-                                    "key": "measurement",
-                                    "value": "gravity"
-                                }
+                                {"key": "axis", "value": "x"},
+                                {"key": "category", "value": "motion"},
+                                {"key": "measurement", "value": "gravity"},
                             ],
                             "min_time": 1659018405.167568,
-                            "max_time": 1659027683.492028
-                        }
-                    ]
+                            "max_time": 1659027683.492028,
+                        },
+                    ],
                 }
             }
         ]
@@ -1377,7 +1314,7 @@ class TestStreamMetadata(TestCase):
         stream_df = get_stream_dataframe(
             stream_ids=["s1", "s2"],
             stream_client=self.mock_stream_client,
-            graph_client=self.mock_graph_client
+            graph_client=self.mock_graph_client,
         )
 
         self.assertEqual(
@@ -1392,7 +1329,7 @@ class TestStreamMetadata(TestCase):
                     "6": "2022-07-28T14:26:45.361596Z",
                     "7": "2022-07-28T14:26:45.361796Z",
                     "8": "2022-07-28T14:26:45.3618588Z",
-                    "9": "2022-07-28T14:26:45.3620749Z"
+                    "9": "2022-07-28T14:26:45.3620749Z",
                 },
                 "acceleration": {
                     "0": 0.0144698024,
@@ -1404,7 +1341,7 @@ class TestStreamMetadata(TestCase):
                     "6": 0.0208349749,
                     "7": 0.0211828612,
                     "8": 0.0221729930,
-                    "9": 0.0235602502
+                    "9": 0.0235602502,
                 },
                 "measurement_duration_ns": {
                     "0": 20000000,
@@ -1416,7 +1353,7 @@ class TestStreamMetadata(TestCase):
                     "6": 20000000,
                     "7": 20000000,
                     "8": 20000000,
-                    "9": 20000000
+                    "9": 20000000,
                 },
                 "algorithm": {
                     "0": "a1",
@@ -1428,7 +1365,7 @@ class TestStreamMetadata(TestCase):
                     "6": "a1",
                     "7": "a1",
                     "8": "a1",
-                    "9": "a1"
+                    "9": "a1",
                 },
                 "device_id": {
                     "0": "d1",
@@ -1440,7 +1377,7 @@ class TestStreamMetadata(TestCase):
                     "6": "d1",
                     "7": "d1",
                     "8": "d1",
-                    "9": "d1"
+                    "9": "d1",
                 },
                 "patient_id": {
                     "0": "p1",
@@ -1452,7 +1389,7 @@ class TestStreamMetadata(TestCase):
                     "6": "p1",
                     "7": "p1",
                     "8": "p1",
-                    "9": "p1"
+                    "9": "p1",
                 },
                 "axis": {
                     "0": "z",
@@ -1464,7 +1401,7 @@ class TestStreamMetadata(TestCase):
                     "6": "x",
                     "7": "x",
                     "8": "x",
-                    "9": "x"
+                    "9": "x",
                 },
                 "category": {
                     "0": "motion",
@@ -1476,7 +1413,7 @@ class TestStreamMetadata(TestCase):
                     "6": "motion",
                     "7": "motion",
                     "8": "motion",
-                    "9": "motion"
+                    "9": "motion",
                 },
                 "measurement": {
                     "0": "user",
@@ -1488,7 +1425,7 @@ class TestStreamMetadata(TestCase):
                     "6": "gravity",
                     "7": "gravity",
                     "8": "gravity",
-                    "9": "gravity"
+                    "9": "gravity",
                 },
                 "stream_type_id": {
                     "0": "acceleration",
@@ -1500,7 +1437,7 @@ class TestStreamMetadata(TestCase):
                     "6": "acceleration",
                     "7": "acceleration",
                     "8": "acceleration",
-                    "9": "acceleration"
+                    "9": "acceleration",
                 },
                 "stream_id": {
                     "0": "s1",
@@ -1512,10 +1449,10 @@ class TestStreamMetadata(TestCase):
                     "6": "s2",
                     "7": "s2",
                     "8": "s2",
-                    "9": "s2"
-                }
+                    "9": "s2",
+                },
             },
-            json.loads(stream_df.to_json())
+            json.loads(stream_df.to_json()),
         )
 
     def test_get_stream_availability_dataframe(self):
@@ -1542,9 +1479,7 @@ class TestStreamMetadata(TestCase):
         self.mock_graph_client.execute.side_effect = [
             {
                 "streamListByIds": {
-                    "pageInfo": {
-                        "endCursor": None
-                    },
+                    "pageInfo": {"endCursor": None},
                     "streams": [
                         {
                             "id": "s1",
@@ -1564,7 +1499,7 @@ class TestStreamMetadata(TestCase):
                                             "quantity_name": "Time",
                                             "quantity_abbrev": "t",
                                             "unit_name": "Seconds",
-                                            "unit_abbrev": "s"
+                                            "unit_abbrev": "s",
                                         },
                                         {
                                             "id": "duration",
@@ -1572,15 +1507,15 @@ class TestStreamMetadata(TestCase):
                                             "quantity_name": "Duration",
                                             "quantity_abbrev": "Duration",
                                             "unit_name": "Seconds",
-                                            "unit_abbrev": "s"
-                                        }
+                                            "unit_abbrev": "s",
+                                        },
                                     ]
-                                }
+                                },
                             },
                             "min_time": 1648231560,
-                            "max_time": 1648234860
+                            "max_time": 1648234860,
                         }
-                    ]
+                    ],
                 }
             }
         ]
@@ -1591,7 +1526,7 @@ class TestStreamMetadata(TestCase):
             end_time=345,
             resolution=300,
             stream_client=self.mock_stream_client,
-            graph_client=self.mock_graph_client
+            graph_client=self.mock_graph_client,
         )
 
         self.assertEqual(
@@ -1603,7 +1538,7 @@ class TestStreamMetadata(TestCase):
                     "3": "2022-07-28T14:26:45.3618588Z",
                     "4": "2022-07-28T14:26:45.3620749Z",
                     "5": "2022-07-28T14:26:45.362149Z",
-                    "6": "2022-07-28T14:26:45.36221Z"
+                    "6": "2022-07-28T14:26:45.36221Z",
                 },
                 "availability": {
                     "0": 1,
@@ -1612,7 +1547,7 @@ class TestStreamMetadata(TestCase):
                     "3": 0,
                     "4": 0,
                     "5": 1,
-                    "6": 1
+                    "6": 1,
                 },
                 "algorithm": {
                     "0": "a1",
@@ -1621,7 +1556,7 @@ class TestStreamMetadata(TestCase):
                     "3": "a1",
                     "4": "a1",
                     "5": "a1",
-                    "6": "a1"
+                    "6": "a1",
                 },
                 "device_id": {
                     "0": "d1",
@@ -1630,7 +1565,7 @@ class TestStreamMetadata(TestCase):
                     "3": "d1",
                     "4": "d1",
                     "5": "d1",
-                    "6": "d1"
+                    "6": "d1",
                 },
                 "patient_id": {
                     "0": "p1",
@@ -1639,7 +1574,7 @@ class TestStreamMetadata(TestCase):
                     "3": "p1",
                     "4": "p1",
                     "5": "p1",
-                    "6": "p1"
+                    "6": "p1",
                 },
                 "stream_type_id": {
                     "0": "duration",
@@ -1657,10 +1592,10 @@ class TestStreamMetadata(TestCase):
                     "3": "s1",
                     "4": "s1",
                     "5": "s1",
-                    "6": "s1"
-                }
+                    "6": "s1",
+                },
             },
-            json.loads(stream_df.to_json())
+            json.loads(stream_df.to_json()),
         )
 
     def test_get_batch_stream_availability_dataframe(self):
@@ -1690,7 +1625,7 @@ class TestStreamMetadata(TestCase):
             end_time=345,
             resolution=300,
             batch_operation="all",
-            stream_client=self.mock_stream_client
+            stream_client=self.mock_stream_client,
         )
 
         self.assertEqual(
@@ -1702,7 +1637,7 @@ class TestStreamMetadata(TestCase):
                     "3": "2022-07-28T14:26:45.3618588Z",
                     "4": "2022-07-28T14:26:45.3620749Z",
                     "5": "2022-07-28T14:26:45.362149Z",
-                    "6": "2022-07-28T14:26:45.36221Z"
+                    "6": "2022-07-28T14:26:45.36221Z",
                 },
                 "availability": {
                     "0": 1,
@@ -1711,8 +1646,8 @@ class TestStreamMetadata(TestCase):
                     "3": 0,
                     "4": 0,
                     "5": 1,
-                    "6": 1
+                    "6": 1,
                 },
             },
-            json.loads(stream_df.to_json())
+            json.loads(stream_df.to_json()),
         )

--- a/tests/resources/test_user.py
+++ b/tests/resources/test_user.py
@@ -21,10 +21,7 @@ class TestUser(TestCase):
 
         """
         self.mock_client = GraphClient(
-            Config(
-                client_key_id='test',
-                client_access_key='config'
-            )
+            Config(client_key_id="test", client_access_key="config")
         )
 
     def test_attributes(self):
@@ -59,10 +56,7 @@ class TestUser(TestCase):
             active_org_name="Org 1",
         )
 
-        self.assertEqual(
-            'User(id="user1-id", name="User 1")',
-            repr(test_user)
-        )
+        self.assertEqual('User(id="user1-id", name="User 1")', repr(test_user))
 
     def test_normalize_id(self):
         """
@@ -71,22 +65,22 @@ class TestUser(TestCase):
         """
         self.assertEqual(
             "d4b1c627bd464fe0a5ed940cc8e8e485",
-            User.normalize_id("user-d4b1c627bd464fe0a5ed940cc8e8e485,user")
+            User.normalize_id("user-d4b1c627bd464fe0a5ed940cc8e8e485,user"),
         )
 
         self.assertEqual(
             "d4b1c627bd464fe0a5ed940cc8e8e485",
-            User.normalize_id("d4b1c627bd464fe0a5ed940cc8e8e485,user")
+            User.normalize_id("d4b1c627bd464fe0a5ed940cc8e8e485,user"),
         )
 
         self.assertEqual(
             "d4b1c627bd464fe0a5ed940cc8e8e485",
-            User.normalize_id("user-d4b1c627bd464fe0a5ed940cc8e8e485")
+            User.normalize_id("user-d4b1c627bd464fe0a5ed940cc8e8e485"),
         )
 
         self.assertEqual(
             "d4b1c627bd464fe0a5ed940cc8e8e485",
-            User.normalize_id("d4b1c627bd464fe0a5ed940cc8e8e485")
+            User.normalize_id("d4b1c627bd464fe0a5ed940cc8e8e485"),
         )
 
     def test_get_user(self):
@@ -101,12 +95,7 @@ class TestUser(TestCase):
                     "id": "user1-id",
                     "created_at": 1629300943.9179766,
                     "name": "user1",
-                    "defaultMembership": {
-                        "org": {
-                            "id": "org1-id",
-                            "name": "org1"
-                        }
-                    },
+                    "defaultMembership": {"org": {"id": "org1-id", "name": "org1"}},
                     "email": "user1@email.com",
                 }
             }

--- a/tests/stream/test_v1.py
+++ b/tests/stream/test_v1.py
@@ -1,16 +1,16 @@
-from unittest import mock, TestCase
-from typing import List, Dict
+from typing import Dict, List
+from unittest import TestCase, mock
 
 import numpy as np
 
-from runeq import Config, stream, errors
+from runeq import Config, errors, stream
 
 
 def mock_get_json_response(
-        bodies: List[dict],
-        calls: List,
-        status_code=200,
-        headers: List[Dict[str, str]] = None
+    bodies: List[dict],
+    calls: List,
+    status_code=200,
+    headers: List[Dict[str, str]] = None,
 ):
     """Return a function that can be used to mock .get_json_response()
 
@@ -33,7 +33,7 @@ def mock_get_json_response(
         resp = mock.MagicMock()
         resp.headers = headers[num]
         resp.status_code = status_code
-        resp.ok = (status_code < 400)
+        resp.ok = status_code < 400
         resp.json.return_value = bodies[num]
         num += 1
         return resp
@@ -42,10 +42,10 @@ def mock_get_json_response(
 
 
 def mock_get_csv_response(
-        bodies: List[str],
-        calls: List,
-        status_code=200,
-        headers: List[Dict[str, str]] = None
+    bodies: List[str],
+    calls: List,
+    status_code=200,
+    headers: List[Dict[str, str]] = None,
 ):
     """Return a function that can be used to mock .get_csv_response()
 
@@ -68,7 +68,7 @@ def mock_get_csv_response(
         resp = mock.MagicMock()
         resp.headers = headers[num]
         resp.status_code = status_code
-        resp.ok = (status_code < 400)
+        resp.ok = status_code < 400
         resp.text = bodies[num]
         num += 1
         return resp
@@ -88,8 +88,8 @@ class TestStreamV1Client(TestCase):
 
         """
         self.cfg = Config(
-            client_key_id='abc',
-            client_access_key='abc123',
+            client_key_id="abc",
+            client_access_key="abc123",
         )
         self.client = stream.V1Client(self.cfg)
         self.use_np_orig = stream.v1.USE_NUMPY
@@ -102,74 +102,76 @@ class TestStreamV1Client(TestCase):
         """
         stream.v1.USE_NUMPY = self.use_np_orig
 
-    @mock.patch('runeq.stream.v1.requests')
+    @mock.patch("runeq.stream.v1.requests")
     def test_get_json_response(self, requests):
         """
         Test the signature of JSON requests.
 
         """
-        for test_num, case in enumerate((
-                (self.client.Accel, '/v1/accel.json'),
-                (self.client.BandPower, '/v1/band_power.json'),
-                (self.client.Event, '/v1/event.json'),
-                (self.client.HeartRate, '/v1/heartrate.json'),
-                (self.client.LFP, '/v1/lfp.json'),
-                (
-                        self.client.ProbabilitySymptom,
-                        '/v1/probability_symptom.json'
-                ),
-                (self.client.Rotation, '/v1/rotation.json'),
-                (self.client.Span, '/v1/span.json'),
-                (self.client.State, '/v1/state.json'),
-        )):
+        for test_num, case in enumerate(
+            (
+                (self.client.Accel, "/v1/accel.json"),
+                (self.client.BandPower, "/v1/band_power.json"),
+                (self.client.Event, "/v1/event.json"),
+                (self.client.HeartRate, "/v1/heartrate.json"),
+                (self.client.LFP, "/v1/lfp.json"),
+                (self.client.ProbabilitySymptom, "/v1/probability_symptom.json"),
+                (self.client.Rotation, "/v1/rotation.json"),
+                (self.client.Span, "/v1/span.json"),
+                (self.client.State, "/v1/state.json"),
+            )
+        ):
             resource_creator, endpoint = case
-            resource = resource_creator(leslie='knope')
-            resource.get_json_response(ron='swanson', test_num=test_num)
-            requests.get.assert_has_calls([
-                mock.call(
-                    self.cfg.stream_url + endpoint,
-                    headers=self.cfg.auth_headers,
-                    params={
-                        'leslie': 'knope',
-                        'ron': 'swanson',
-                        'test_num': test_num,
-                    }
-                ),
-            ])
+            resource = resource_creator(leslie="knope")
+            resource.get_json_response(ron="swanson", test_num=test_num)
+            requests.get.assert_has_calls(
+                [
+                    mock.call(
+                        self.cfg.stream_url + endpoint,
+                        headers=self.cfg.auth_headers,
+                        params={
+                            "leslie": "knope",
+                            "ron": "swanson",
+                            "test_num": test_num,
+                        },
+                    ),
+                ]
+            )
 
-    @mock.patch('runeq.stream.v1.requests')
+    @mock.patch("runeq.stream.v1.requests")
     def test_get_csv_response(self, requests):
         """
         Test the signature of CSV requests.
 
         """
-        for test_num, case in enumerate((
-                (self.client.Accel, '/v1/accel.csv'),
-                (self.client.BandPower, '/v1/band_power.csv'),
-                (self.client.HeartRate, '/v1/heartrate.csv'),
-                (self.client.LFP, '/v1/lfp.csv'),
-                (
-                        self.client.ProbabilitySymptom,
-                        '/v1/probability_symptom.csv'
-                ),
-                (self.client.Rotation, '/v1/rotation.csv'),
-                (self.client.State, '/v1/state.csv'),
-        )):
+        for test_num, case in enumerate(
+            (
+                (self.client.Accel, "/v1/accel.csv"),
+                (self.client.BandPower, "/v1/band_power.csv"),
+                (self.client.HeartRate, "/v1/heartrate.csv"),
+                (self.client.LFP, "/v1/lfp.csv"),
+                (self.client.ProbabilitySymptom, "/v1/probability_symptom.csv"),
+                (self.client.Rotation, "/v1/rotation.csv"),
+                (self.client.State, "/v1/state.csv"),
+            )
+        ):
             resource_creator, endpoint = case
-            resource = resource_creator(leslie='knope')
-            resource.get_csv_response(ron='swanson', test_num=test_num)
-            requests.get.assert_has_calls([
-                mock.call(
-                    self.cfg.stream_url + endpoint,
-                    stream=True,
-                    headers=self.cfg.auth_headers,
-                    params={
-                        'leslie': 'knope',
-                        'ron': 'swanson',
-                        'test_num': test_num,
-                    }
-                ),
-            ])
+            resource = resource_creator(leslie="knope")
+            resource.get_csv_response(ron="swanson", test_num=test_num)
+            requests.get.assert_has_calls(
+                [
+                    mock.call(
+                        self.cfg.stream_url + endpoint,
+                        stream=True,
+                        headers=self.cfg.auth_headers,
+                        params={
+                            "leslie": "knope",
+                            "ron": "swanson",
+                            "test_num": test_num,
+                        },
+                    ),
+                ]
+            )
 
     def test_iter_json_data_with_token(self):
         """
@@ -177,7 +179,8 @@ class TestStreamV1Client(TestCase):
         token header.
 
         """
-        for test_num, resource_creator in enumerate((
+        for test_num, resource_creator in enumerate(
+            (
                 self.client.Accel,
                 self.client.BandPower,
                 self.client.Event,
@@ -187,12 +190,13 @@ class TestStreamV1Client(TestCase):
                 self.client.Rotation,
                 self.client.Span,
                 self.client.State,
-        )):
+            )
+        ):
             resource = resource_creator()
 
             mock_responses = [
-                {'success': True, 'result': [], 'next_page': 1},
-                {'success': True, 'result': []}
+                {"success": True, "result": [], "next_page": 1},
+                {"success": True, "result": []},
             ]
 
             calls = []
@@ -201,9 +205,9 @@ class TestStreamV1Client(TestCase):
                 calls,
                 200,
                 [
-                    {'X-Rune-Next-Page-Token': 'MTIzNDU2MDAwMA=='},
+                    {"X-Rune-Next-Page-Token": "MTIzNDU2MDAwMA=="},
                     {},
-                ]
+                ],
             )
 
             iterator = resource.iter_json_data(test_num=test_num)
@@ -211,16 +215,13 @@ class TestStreamV1Client(TestCase):
 
             # Check that all parameters were kept the same across calls,
             # except for "next_page_token"
-            self.assertEqual(calls, [
-                ((), {'test_num': test_num}),
-                (
-                    (),
-                    {
-                        'test_num': test_num,
-                        'next_page_token': 'MTIzNDU2MDAwMA=='
-                    }
-                )
-            ])
+            self.assertEqual(
+                calls,
+                [
+                    ((), {"test_num": test_num}),
+                    ((), {"test_num": test_num, "next_page_token": "MTIzNDU2MDAwMA=="}),
+                ],
+            )
 
     def test_iter_json_data(self):
         """
@@ -228,16 +229,14 @@ class TestStreamV1Client(TestCase):
         the page number.
 
         """
-        results = [
-            {'a': 1},
-            {'b': 2}
-        ]
+        results = [{"a": 1}, {"b": 2}]
         mock_responses = [
-            {'success': True, 'result': results[0], 'next_page': 1},
-            {'success': True, 'result': results[1]}
+            {"success": True, "result": results[0], "next_page": 1},
+            {"success": True, "result": results[1]},
         ]
 
-        for test_num, resource_creator in enumerate((
+        for test_num, resource_creator in enumerate(
+            (
                 self.client.Accel,
                 self.client.BandPower,
                 self.client.Event,
@@ -246,17 +245,15 @@ class TestStreamV1Client(TestCase):
                 self.client.ProbabilitySymptom,
                 self.client.Rotation,
                 self.client.State,
-        )):
+            )
+        ):
             resource = resource_creator()
 
             #
             # Successful Requests
             #
             calls = []
-            resource.get_json_response = mock_get_json_response(
-                mock_responses,
-                calls
-            )
+            resource.get_json_response = mock_get_json_response(mock_responses, calls)
 
             # Check the results
             num_results = 0
@@ -269,10 +266,10 @@ class TestStreamV1Client(TestCase):
 
             # Check that all parameters were kept the same across calls,
             # except for "page" (which must be incremented)
-            self.assertEqual(calls, [
-                ((), {'test_num': test_num}),
-                ((), {'test_num': test_num, 'page': 1})
-            ])
+            self.assertEqual(
+                calls,
+                [((), {"test_num": test_num}), ((), {"test_num": test_num, "page": 1})],
+            )
 
             #
             # Request Error
@@ -283,7 +280,7 @@ class TestStreamV1Client(TestCase):
                 "type": "TestError",
             }
             resource.get_json_response = mock_get_json_response(
-                [{'success': False, 'error': err_details}],
+                [{"success": False, "error": err_details}],
                 [],
                 status_code=404,
             )
@@ -301,12 +298,13 @@ class TestStreamV1Client(TestCase):
 
         """
         mock_responses = [
-            'good,better\nskiing,hiking\n',
-            'good,better\ncupcakes,brownies\n',
-            '',
+            "good,better\nskiing,hiking\n",
+            "good,better\ncupcakes,brownies\n",
+            "",
         ]
 
-        for test_num, resource_creator in enumerate((
+        for test_num, resource_creator in enumerate(
+            (
                 self.client.Accel,
                 self.client.BandPower,
                 self.client.HeartRate,
@@ -314,7 +312,8 @@ class TestStreamV1Client(TestCase):
                 self.client.ProbabilitySymptom,
                 self.client.Rotation,
                 self.client.State,
-        )):
+            )
+        ):
             resource = resource_creator()
 
             #
@@ -326,8 +325,8 @@ class TestStreamV1Client(TestCase):
                 calls,
                 200,
                 [
-                    {'X-Rune-Next-Page-Token': 'MTIzNDU2MDAwMA=='},
-                    {'X-Rune-Next-Page-Token': 'MTIzNDU2MDAwMA=='},
+                    {"X-Rune-Next-Page-Token": "MTIzNDU2MDAwMA=="},
+                    {"X-Rune-Next-Page-Token": "MTIzNDU2MDAwMA=="},
                     {},
                 ],
             )
@@ -339,35 +338,27 @@ class TestStreamV1Client(TestCase):
             # Check that all parameters were kept the same across calls,
             # except for "next_page_token" (which will normally be different
             # for each response)
-            self.assertEqual(calls, [
-                ((), {'test_num': test_num}),
-                (
-                    (),
-                    {
-                        'test_num': test_num,
-                        'next_page_token': 'MTIzNDU2MDAwMA=='
-                    }
-                ),
-                (
-                    (),
-                    {
-                        'test_num': test_num,
-                        'next_page_token': 'MTIzNDU2MDAwMA=='
-                    }
-                ),
-            ])
+            self.assertEqual(
+                calls,
+                [
+                    ((), {"test_num": test_num}),
+                    ((), {"test_num": test_num, "next_page_token": "MTIzNDU2MDAwMA=="}),
+                    ((), {"test_num": test_num, "next_page_token": "MTIzNDU2MDAwMA=="}),
+                ],
+            )
 
     def test_iter_csv_data(self):
         """
         Test the iterator over CSV responses, which follows pagination
         """
         mock_responses = [
-            'good,better\nskiing,hiking\n',
-            'good,better\ncupcakes,brownies\n',
-            '',
+            "good,better\nskiing,hiking\n",
+            "good,better\ncupcakes,brownies\n",
+            "",
         ]
 
-        for test_num, resource_creator in enumerate((
+        for test_num, resource_creator in enumerate(
+            (
                 self.client.Accel,
                 self.client.BandPower,
                 self.client.HeartRate,
@@ -375,7 +366,8 @@ class TestStreamV1Client(TestCase):
                 self.client.ProbabilitySymptom,
                 self.client.Rotation,
                 self.client.State,
-        )):
+            )
+        ):
             resource = resource_creator()
 
             #
@@ -400,11 +392,14 @@ class TestStreamV1Client(TestCase):
 
             # Check that all parameters were kept the same across calls,
             # except for "page" (which must be incremented)
-            self.assertEqual(calls, [
-                ((), {'test_num': test_num}),
-                ((), {'test_num': test_num, 'page': 1}),
-                ((), {'test_num': test_num, 'page': 2}),
-            ])
+            self.assertEqual(
+                calls,
+                [
+                    ((), {"test_num": test_num}),
+                    ((), {"test_num": test_num, "page": 1}),
+                    ((), {"test_num": test_num, "page": 2}),
+                ],
+            )
 
             #
             # Request Error
@@ -416,7 +411,7 @@ class TestStreamV1Client(TestCase):
             }
             # note: CSV endpoints return JSON on API errors
             resource.get_csv_response = mock_get_json_response(
-                [{'success': False, 'error': err_details}],
+                [{"success": False, "error": err_details}],
                 [],
                 status_code=404,
             )
@@ -434,17 +429,18 @@ class TestStreamV1Client(TestCase):
 
         """
         mock_responses = [
-            'lower,higher,label\n1,2,ints\n3.5,6.7,floats\n',
-            'lower,higher,label\n,8.9,missing data\n',
-            '',
+            "lower,higher,label\n1,2,ints\n3.5,6.7,floats\n",
+            "lower,higher,label\n,8.9,missing data\n",
+            "",
         ]
         expected = [
-            {'lower': 1, 'higher': 2, 'label': 'ints'},
-            {'lower': 3.5, 'higher': 6.7, 'label': 'floats'},
-            {'lower': None, 'higher': 8.9, 'label': 'missing data'},
+            {"lower": 1, "higher": 2, "label": "ints"},
+            {"lower": 3.5, "higher": 6.7, "label": "floats"},
+            {"lower": None, "higher": 8.9, "label": "missing data"},
         ]
 
-        for test_num, resource_creator in enumerate((
+        for test_num, resource_creator in enumerate(
+            (
                 self.client.Accel,
                 self.client.BandPower,
                 self.client.HeartRate,
@@ -452,7 +448,8 @@ class TestStreamV1Client(TestCase):
                 self.client.ProbabilitySymptom,
                 self.client.Rotation,
                 self.client.State,
-        )):
+            )
+        ):
             resource = resource_creator()
             # replace get_csv_response on the resource
             resource.get_csv_response = mock_get_csv_response(
@@ -473,7 +470,7 @@ class TestStreamV1Client(TestCase):
                 self.assertDictEqual(expected[i], point)
                 # check dtype for "higher", which always has a numeric
                 # value in the test data
-                self.assertNotIsInstance(point['higher'], np.float64)
+                self.assertNotIsInstance(point["higher"], np.float64)
 
     def test_iter_points_numpy(self):
         """
@@ -483,17 +480,18 @@ class TestStreamV1Client(TestCase):
         stream.v1.USE_NUMPY = True
 
         mock_responses = [
-            'lower,higher,label\n1,2,ints\n3.5,6.7,floats\n',
-            'lower,higher,label\n,8.9,missing data\n',
-            '',
+            "lower,higher,label\n1,2,ints\n3.5,6.7,floats\n",
+            "lower,higher,label\n,8.9,missing data\n",
+            "",
         ]
         expected = [
-            {'lower': 1, 'higher': 2, 'label': 'ints'},
-            {'lower': 3.5, 'higher': 6.7, 'label': 'floats'},
-            {'lower': np.NaN, 'higher': 8.9, 'label': 'missing data'},
+            {"lower": 1, "higher": 2, "label": "ints"},
+            {"lower": 3.5, "higher": 6.7, "label": "floats"},
+            {"lower": np.NaN, "higher": 8.9, "label": "missing data"},
         ]
 
-        for test_num, resource_creator in enumerate((
+        for test_num, resource_creator in enumerate(
+            (
                 self.client.Accel,
                 self.client.BandPower,
                 self.client.HeartRate,
@@ -501,7 +499,8 @@ class TestStreamV1Client(TestCase):
                 self.client.ProbabilitySymptom,
                 self.client.Rotation,
                 self.client.State,
-        )):
+            )
+        ):
             resource = resource_creator()
             # replace get_csv_response on the resource
             resource.get_csv_response = mock_get_csv_response(
@@ -513,4 +512,4 @@ class TestStreamV1Client(TestCase):
                 self.assertDictEqual(expected[i], point)
                 # check dtype for "higher", which always has a numeric
                 # value in the test data
-                self.assertIsInstance(point['higher'], np.float64)
+                self.assertIsInstance(point["higher"], np.float64)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,5 @@
 import os
-from unittest import mock, TestCase
+from unittest import TestCase, mock
 
 from runeq import Config
 
@@ -7,21 +7,12 @@ TEST_ROOT = os.path.dirname(os.path.realpath(__file__))
 
 
 class TestConfig(TestCase):
-
     @classmethod
     def setUpClass(cls) -> None:
-        cls.access_token_good_config = (
-            f'{TEST_ROOT}/data/access_token_good_config.yaml'
-        )
-        cls.access_token_bad_config = (
-            f'{TEST_ROOT}/data/access_token_bad_config.yaml'
-        )
-        cls.client_keys_good_config = (
-            f'{TEST_ROOT}/data/client_keys_good_config.yaml'
-        )
-        cls.client_keys_bad_config = (
-            f'{TEST_ROOT}/data/client_keys_bad_config.yaml'
-        )
+        cls.access_token_good_config = f"{TEST_ROOT}/data/access_token_good_config.yaml"
+        cls.access_token_bad_config = f"{TEST_ROOT}/data/access_token_bad_config.yaml"
+        cls.client_keys_good_config = f"{TEST_ROOT}/data/client_keys_good_config.yaml"
+        cls.client_keys_bad_config = f"{TEST_ROOT}/data/client_keys_bad_config.yaml"
 
     def test_init_file(self):
         """
@@ -30,8 +21,8 @@ class TestConfig(TestCase):
         # Test access tokens init
         cfg = Config(self.access_token_good_config)
         expected = {
-            'X-Rune-User-Access-Token-Id': 'foo',
-            'X-Rune-User-Access-Token-Secret': 'bar',
+            "X-Rune-User-Access-Token-Id": "foo",
+            "X-Rune-User-Access-Token-Secret": "bar",
         }
         self.assertEqual(expected, cfg.auth_headers)
         self.assertEqual(expected, cfg.access_token_auth_headers)
@@ -46,8 +37,8 @@ class TestConfig(TestCase):
         cfg = Config(self.client_keys_good_config)
 
         expected = {
-            'X-Rune-Client-Key-ID': 'abc',
-            'X-Rune-Client-Access-Key': 'def',
+            "X-Rune-Client-Key-ID": "abc",
+            "X-Rune-Client-Access-Key": "def",
         }
         self.assertEqual(expected, cfg.auth_headers)
         self.assertEqual(expected, cfg.client_auth_headers)
@@ -57,7 +48,7 @@ class TestConfig(TestCase):
         with self.assertRaises(ValueError):
             _ = cfg.access_token_auth_headers
 
-        self.assertEqual('https://foo.runelabs.io', cfg.stream_url)
+        self.assertEqual("https://foo.runelabs.io", cfg.stream_url)
 
     def test_init_file_invalid(self):
         """
@@ -76,22 +67,13 @@ class TestConfig(TestCase):
         Test initializing with valid kwargs
         """
         # access token
-        cfg = Config(
-            access_token_id='foo',
-            access_token_secret='bar'
-        )
+        cfg = Config(access_token_id="foo", access_token_secret="bar")
         access_token_headers = {
-            'X-Rune-User-Access-Token-Id': 'foo',
-            'X-Rune-User-Access-Token-Secret': 'bar',
+            "X-Rune-User-Access-Token-Id": "foo",
+            "X-Rune-User-Access-Token-Secret": "bar",
         }
-        self.assertEqual(
-            access_token_headers,
-            cfg.auth_headers
-        )
-        self.assertEqual(
-            access_token_headers,
-            cfg.access_token_auth_headers
-        )
+        self.assertEqual(access_token_headers, cfg.auth_headers)
+        self.assertEqual(access_token_headers, cfg.access_token_auth_headers)
         with self.assertRaises(ValueError):
             _ = cfg.client_auth_headers
 
@@ -100,12 +82,12 @@ class TestConfig(TestCase):
 
         # client keys
         cfg = Config(
-            client_key_id='abc',
-            client_access_key='123',
+            client_key_id="abc",
+            client_access_key="123",
         )
         client_headers = {
-            'X-Rune-Client-Key-ID': 'abc',
-            'X-Rune-Client-Access-Key': '123',
+            "X-Rune-Client-Key-ID": "abc",
+            "X-Rune-Client-Access-Key": "123",
         }
         self.assertEqual(client_headers, cfg.auth_headers)
         self.assertEqual(client_headers, cfg.client_auth_headers)
@@ -116,10 +98,8 @@ class TestConfig(TestCase):
             _ = cfg.access_token_auth_headers
 
         # jwt
-        cfg = Config(jwt='abc123')
-        jwt_headers = {
-            'X-Rune-User-Access-Token': 'abc123'
-        }
+        cfg = Config(jwt="abc123")
+        jwt_headers = {"X-Rune-User-Access-Token": "abc123"}
         self.assertEqual(jwt_headers, cfg.auth_headers)
         self.assertEqual(jwt_headers, cfg.jwt_auth_headers)
         with self.assertRaises(ValueError):
@@ -129,20 +109,16 @@ class TestConfig(TestCase):
             _ = cfg.access_token_auth_headers
 
         # cognito refresh token
-        with mock.patch('runeq.config.boto3.client') as boto3_client:
+        with mock.patch("runeq.config.boto3.client") as boto3_client:
             mock_cognito = mock.Mock()
             mock_cognito.initiate_auth.return_value = {
-                'AuthenticationResult': {
-                    'AccessToken': 'def456'
-                }
+                "AuthenticationResult": {"AccessToken": "def456"}
             }
             boto3_client.return_value = mock_cognito
 
-            cfg = Config(cognito_refresh_token='ref', cognito_client_id='cli')
+            cfg = Config(cognito_refresh_token="ref", cognito_client_id="cli")
 
-        cognito_jwt_headers = {
-            'X-Rune-User-Access-Token': 'def456'
-        }
+        cognito_jwt_headers = {"X-Rune-User-Access-Token": "def456"}
         self.assertEqual(cognito_jwt_headers, cfg.auth_headers)
         self.assertEqual(cognito_jwt_headers, cfg.jwt_auth_headers)
         with self.assertRaises(ValueError):
@@ -151,45 +127,37 @@ class TestConfig(TestCase):
         with self.assertRaises(ValueError):
             _ = cfg.access_token_auth_headers
 
-    @mock.patch('runeq.config.boto3.client')
+    @mock.patch("runeq.config.boto3.client")
     def test_refresh_auth(self, mock_boto3):
         """Test that refresh_auth updates JWT value and returns a bool"""
         mock_cognito = mock.Mock()
         mock_cognito.initiate_auth.return_value = {
-            'AuthenticationResult': {
-                'AccessToken': 'jwt1'
-            }
+            "AuthenticationResult": {"AccessToken": "jwt1"}
         }
         mock_boto3.return_value = mock_cognito
 
         # refresh_auth returns False if the Config isn't using a refresh token
         for cfg in (
-            Config(client_key_id='abc', client_access_key='123'),
-            Config(access_token_id='foo', access_token_secret='bar'),
-            Config(jwt='abc123')
+            Config(client_key_id="abc", client_access_key="123"),
+            Config(access_token_id="foo", access_token_secret="bar"),
+            Config(jwt="abc123"),
         ):
             self.assertFalse(cfg.refresh_auth())
             mock_cognito.initiate_auth.assert_not_called()
 
         # with a refresh token, initiate_auth is called once on init
-        cfg = Config(cognito_refresh_token='ref', cognito_client_id='cli')
+        cfg = Config(cognito_refresh_token="ref", cognito_client_id="cli")
         self.assertEqual(mock_cognito.initiate_auth.call_count, 1)
-        self.assertEqual(cfg.auth_headers, {
-            'X-Rune-User-Access-Token': 'jwt1'
-        })
+        self.assertEqual(cfg.auth_headers, {"X-Rune-User-Access-Token": "jwt1"})
 
         # check that auth headers change after refreshing
         mock_cognito.initiate_auth.return_value = {
-            'AuthenticationResult': {
-                'AccessToken': 'jwt2'
-            }
+            "AuthenticationResult": {"AccessToken": "jwt2"}
         }
         self.assertTrue(cfg.refresh_auth())
 
         self.assertEqual(mock_cognito.initiate_auth.call_count, 2)
-        self.assertEqual(cfg.auth_headers, {
-            'X-Rune-User-Access-Token': 'jwt2'
-        })
+        self.assertEqual(cfg.auth_headers, {"X-Rune-User-Access-Token": "jwt2"})
 
     def test_init_kwargs_invalid(self):
         """
@@ -197,35 +165,28 @@ class TestConfig(TestCase):
 
         """
         with self.assertRaises(ValueError):
-            Config(client_key_id='abc')
+            Config(client_key_id="abc")
 
         with self.assertRaises(ValueError):
-            Config(client_access_key='123')
+            Config(client_access_key="123")
 
         with self.assertRaises(ValueError):
-            Config(client_access_key='123', jwt='abc123')
+            Config(client_access_key="123", jwt="abc123")
 
         with self.assertRaises(ValueError):
-            Config(access_token_id='foo')
+            Config(access_token_id="foo")
 
         with self.assertRaises(ValueError):
-            Config(
-                access_token_id='foo',
-                client_access_key='123'
-            )
+            Config(access_token_id="foo", client_access_key="123")
 
         with self.assertRaises(ValueError):
-            Config(
-                access_token_id='foo',
-                client_access_key='123',
-                jwt='zee'
-            )
+            Config(access_token_id="foo", client_access_key="123", jwt="zee")
 
         with self.assertRaises(ValueError):
             Config(
-                jwt='zee',
-                cognito_client_id='foo',
-                cognito_refresh_token='bar',
+                jwt="zee",
+                cognito_client_id="foo",
+                cognito_refresh_token="bar",
             )
 
     def test_init_invalid(self):
@@ -233,7 +194,4 @@ class TestConfig(TestCase):
         Cannot initialize with a filename and kwargs
         """
         with self.assertRaises(TypeError):
-            Config(
-                self.client_keys_good_config,
-                stream_url='https://bar.runelabs.io'
-            )
+            Config(self.client_keys_good_config, stream_url="https://bar.runelabs.io")


### PR DESCRIPTION
Adding our standard autoformatting tools (black and isort).

Manual changes were made in:
* `Makefile` -- adding targets to check and format
* `.isort.cfg` and `.flake8` -- standard config
* `requirements/dev.txt` -- adding the new requirements

All other changes were made by running `make format`.