### PR TITLE
[SW-6282] Remove support for Project and Cohort metrics

### DIFF
--- a/docs/pages/quickstart.rst
+++ b/docs/pages/quickstart.rst
@@ -172,27 +172,23 @@ You can find information about a single project:
 
 .. code-block:: python
 
-    from runeq.resources.project import get_project, get_project_patients
+    from runeq.resources.project import get_project, get_project_patients, get_cohort_patients
 
-    project = get_project(project_id="example_id")
+    # Fetch basic metadata about a project (title, description, cohorts)
+    project = get_project(project_id="example_project_id")
     print(project.to_dict())
 
-    project_patients = get_project_patients(project_id="example_id")
-
+    # Fetch metadata for the patients within a project
+    project_patients = get_project_patients(project_id="example_project_id")
     for project_patient in project_patients:
         print(project_patient)
 
+    # You can create a dataframe of the project patient metadata
+    project_patient_metadata_df = project_patients.to_dataframe()
 
-It may be easier to view a single project patient in a dataframe which you can do by:
-
-.. code-block:: python
-
-    from runeq.resources.project import get_project_patients
-
-    project_patients = get_project_patients(project_id="example_id")
-    target_patient_id = "patient_id_example"
-
-    df = project_patients[target_patient_id].get_patient_metadata_dataframe()
+    # You can also fetch the list of patients in a cohort, using a cohort ID.
+    cohort_patients = get_cohort_patients(cohort_id="example_cohort_id")
+    cohort_patient_metadata_df = cohort_patients.to_dataframe()
 
 
 Fetch Timeseries Data

--- a/docs/pages/quickstart.rst
+++ b/docs/pages/quickstart.rst
@@ -172,26 +172,16 @@ You can find information about a single project:
 
 .. code-block:: python
 
-    from runeq.resources.project import get_project
+    from runeq.resources.project import get_project, get_project_patients
 
     project = get_project(project_id="example_id")
     print(project.to_dict())
-
-To view all the patients in a project, and their related project metrics you can use the
-following example:
-
-.. code-block:: python
-
-    from runeq.resources.project import get_project_patients
 
     project_patients = get_project_patients(project_id="example_id")
 
     for project_patient in project_patients:
         print(project_patient)
-        for metric in project_patient.metrics:
-            print(' ', metric)
 
-        print('')
 
 It may be easier to view a single project patient in a dataframe which you can do by:
 
@@ -203,8 +193,6 @@ It may be easier to view a single project patient in a dataframe which you can d
     target_patient_id = "patient_id_example"
 
     df = project_patients[target_patient_id].get_patient_metadata_dataframe()
-
-    df
 
 
 Fetch Timeseries Data

--- a/docs/pages/resources.rst
+++ b/docs/pages/resources.rst
@@ -174,11 +174,3 @@ Cohorts
    :special-members: __init__
    :members:
    :inherited-members:
-.. autoclass:: CohortPatientMetadata
-   :special-members: __init__
-   :members:
-   :inherited-members:
-.. autoclass:: CohortPatientMetadataSet
-   :special-members: __init__
-   :members:
-   :inherited-members:

--- a/docs/pages/resources.rst
+++ b/docs/pages/resources.rst
@@ -182,16 +182,3 @@ Cohorts
    :special-members: __init__
    :members:
    :inherited-members:
-
-
-Metrics
-********
-
-.. autoclass:: Metric
-   :special-members: __init__
-   :members:
-   :inherited-members:
-.. autoclass:: MetricSet
-   :special-members: __init__
-   :members:
-   :inherited-members:

--- a/runeq/resources/common.py
+++ b/runeq/resources/common.py
@@ -2,6 +2,7 @@
 Common utilities and base classes.
 
 """
+
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from typing import Any, Dict, Iterable, Iterator, List, Type, Union

--- a/runeq/resources/project.py
+++ b/runeq/resources/project.py
@@ -21,6 +21,7 @@ class ProjectPatientMetadata(ItemBase):
     def __init__(
         self,
         id: str,
+        project_code_name: str,
         updated_at: float,
         created_at: float,
         created_by: str,
@@ -31,7 +32,8 @@ class ProjectPatientMetadata(ItemBase):
         Initialize with data.
 
         Args:
-            id: Patient ID of the patient in the cohort
+            id: Patient ID
+            project_code_name: Code name of the patient within the project
             created_at: Time patient was added to the project (unix timestamp)
             created_by: Display name of who added the patient to the project
             updated_at: Time project patient was last updated (unix timestamp)
@@ -43,9 +45,11 @@ class ProjectPatientMetadata(ItemBase):
         self.updated_at = updated_at
         self.created_by = created_by
         self.updated_by = updated_by
+        self.project_code_name = project_code_name
 
         super().__init__(
             id=id,
+            project_code_name=project_code_name,
             created_at=created_at,
             updated_at=updated_at,
             created_by=created_by,
@@ -72,65 +76,6 @@ class ProjectPatientMetadata(ItemBase):
         )
 
         return metadata_df
-
-
-class CohortPatientMetadata(ProjectPatientMetadata):
-    """
-    Cohort related information about a patient contained in a cohort.
-
-    """
-
-    def __init__(
-        self,
-        id: str,
-        updated_at: float,
-        created_at: float,
-        created_by: str,
-        updated_by: str,
-        **attributes
-    ):
-        """
-        Initialize with data.
-
-        Args:
-            id: Patient ID of the patient in the cohort
-            created_at: Time patient was added to the cohort (unix timestamp)
-            created_by: Display name of who added the patient to the cohort
-            updated_at: Time cohort patient was last updated (unix timestamp)
-            updated_by: Display name of who updated the cohort patient record
-            **attributes: Other attributes associated with the cohort
-
-        """
-        super().__init__(
-            id=id,
-            created_at=created_at,
-            updated_at=updated_at,
-            created_by=created_by,
-            updated_by=updated_by,
-            **attributes,
-        )
-
-
-class CohortPatientMetadataSet(ItemSet):
-    """
-    A collection of CohortPatientMetadata.
-
-    """
-
-    def __init__(self, items: Iterable[CohortPatientMetadata] = ()):
-        """
-        Initialize with CohortPatientMetadata.
-
-        """
-        super().__init__(items=items)
-
-    @property
-    def _item_class(self) -> Type[ItemBase]:
-        """
-        Instance type of items in this set.
-
-        """
-        return CohortPatientMetadata
 
 
 class ProjectPatientMetadataSet(ItemSet):
@@ -482,7 +427,7 @@ def get_project_patients(
                         patient {
                             id
                         },
-                        code_name: codeName,
+                        project_code_name: codeName,
                         created_at: createdAt,
                         updated_at: updatedAt,
                         created_by: createdBy,
@@ -533,7 +478,7 @@ def get_project_patients(
 def get_cohort_patients(
     cohort_id: str,
     client: Optional[GraphClient] = None,
-) -> CohortPatientMetadataSet:
+) -> ProjectPatientMetadataSet:
     """
     Get all patients in a cohort.
 
@@ -553,7 +498,7 @@ def get_cohort_patients(
                         patient {
                             id
                         }
-                        code_name: codeName,
+                        project_code_name: codeName,
                         created_at: createdAt,
                         updated_at: updatedAt,
                         created_by: createdBy,
@@ -567,7 +512,7 @@ def get_cohort_patients(
         }
     """
     cursor_input = None
-    cohort_patient_set = CohortPatientMetadataSet()
+    cohort_patient_set = ProjectPatientMetadataSet()
 
     while True:
         result = client.execute(
@@ -586,7 +531,7 @@ def get_cohort_patients(
             patient_attrs["id"] = patient_attrs.get("patient").get("id")
             del patient_attrs["patient"]
 
-            patient = CohortPatientMetadata(**patient_attrs)
+            patient = ProjectPatientMetadata(**patient_attrs)
             cohort_patient_set.add(patient)
 
         cursor = cohort_patient_list.get("pageInfo", {}).get("codeNameEndCursor")

--- a/runeq/resources/project.py
+++ b/runeq/resources/project.py
@@ -26,7 +26,7 @@ class ProjectPatientMetadata(ItemBase):
         created_at: float,
         created_by: str,
         updated_by: str,
-        **attributes
+        **attributes,
     ):
         """
         Initialize with data.
@@ -57,6 +57,16 @@ class ProjectPatientMetadata(ItemBase):
             **attributes,
         )
 
+    def __repr__(self):
+        """
+        Override the  the item representation.
+
+        """
+        return (
+            f"{self.__class__.__name__}"
+            f'(patient_id="{self.id}", project_code_name="{self.project_code_name}")'
+        )
+
     def to_dict(self) -> dict:
         """
         Dictionary representation of the Project Patient attributes.
@@ -64,18 +74,6 @@ class ProjectPatientMetadata(ItemBase):
         """
         attrs = self._attributes.copy()
         return attrs
-
-    def get_patient_metadata_dataframe(self) -> pd.DataFrame:
-        """
-        Returns a new dataframe displaying the patient's metadata.
-
-        """
-        metadata_obj = self.to_dict()
-        metadata_df = pd.DataFrame(metadata_obj).rename(
-            columns={"code_name": "project_patient_code_name"}
-        )
-
-        return metadata_df
 
 
 class ProjectPatientMetadataSet(ItemSet):
@@ -116,7 +114,7 @@ class Cohort(ItemBase):
         created_at: float,
         created_by: str,
         updated_by: str,
-        **attributes
+        **attributes,
     ):
         """
         Initialize with data.
@@ -146,6 +144,13 @@ class Cohort(ItemBase):
             updated_by=updated_by,
             **attributes,
         )
+
+    def __repr__(self):
+        """
+        Override the  the item representation.
+
+        """
+        return f"{self.__class__.__name__}" f'(id="{self.id}", title="{self.title}")'
 
 
 class CohortSet(ItemSet):
@@ -192,7 +197,7 @@ class Project(ItemBase):
         created_by: str,
         updated_by: str,
         cohorts: CohortSet,
-        **attributes
+        **attributes,
     ):
         """
         Initialize with data.
@@ -236,6 +241,13 @@ class Project(ItemBase):
             cohorts=cohorts,
             **attributes,
         )
+
+    def __repr__(self):
+        """
+        Override the  the item representation.
+
+        """
+        return f"{self.__class__.__name__}" f'(id="{self.id}", title="{self.title}")'
 
     def to_dict(self) -> dict:
         """

--- a/runeq/resources/project.py
+++ b/runeq/resources/project.py
@@ -57,7 +57,7 @@ class ProjectPatientMetadata(ItemBase):
 
     def __repr__(self):
         """
-        Override the  the item representation.
+        Override the item representation.
 
         """
         return (
@@ -145,7 +145,7 @@ class Cohort(ItemBase):
 
     def __repr__(self):
         """
-        Override the  the item representation.
+        Override the item representation.
 
         """
         return f"{self.__class__.__name__}" f'(id="{self.id}", title="{self.title}")'
@@ -242,7 +242,7 @@ class Project(ItemBase):
 
     def __repr__(self):
         """
-        Override the  the item representation.
+        Override the item representation.
 
         """
         return f"{self.__class__.__name__}" f'(id="{self.id}", title="{self.title}")'

--- a/runeq/resources/project.py
+++ b/runeq/resources/project.py
@@ -5,8 +5,6 @@ Fetch metadata about projects.
 
 from typing import Iterable, Optional, Type
 
-import pandas as pd
-
 from .client import GraphClient, global_graph_client
 from .common import ItemBase, ItemSet
 

--- a/runeq/stream/v1.py
+++ b/runeq/stream/v1.py
@@ -306,7 +306,7 @@ class StreamV1CSVBase(StreamV1Base):
 
         """
         if USE_NUMPY:
-            restval = np.NaN
+            restval = np.nan
         else:
             restval = None
 

--- a/tests/resources/test_project.py
+++ b/tests/resources/test_project.py
@@ -2,6 +2,7 @@
 Tests for fetching project data.
 
 """
+
 from unittest import TestCase, mock
 
 from runeq.config import Config
@@ -10,8 +11,6 @@ from runeq.resources.project import (
     Cohort,
     CohortPatientMetadata,
     CohortSet,
-    Metric,
-    MetricSet,
     Project,
     ProjectPatientMetadata,
     get_cohort_patients,
@@ -367,19 +366,6 @@ class TestProject(TestCase):
         Test attributes for an initialized Project Patient.
 
         """
-        example_metrics = MetricSet(
-            [
-                Metric(
-                    type="LAST_UPLOAD",
-                    data_type="APPLEWATCH_TREMOR",
-                    value=1648235452.965804,
-                    time_interval="FOURTEEN_DAYS",
-                    created_at=1673467628.837126,
-                    updated_at=1673467628.837126,
-                    id="1bfcf11f-8d5c-4714-b774-6b47e03c5900",
-                ),
-            ]
-        )
         test_project = ProjectPatientMetadata(
             id="proj-patient-id",
             created_at=1630515986.9949625,
@@ -387,7 +373,6 @@ class TestProject(TestCase):
             created_by="user-1",
             updated_by="user-1",
             started_at=1630515986.9949625,
-            metrics=example_metrics,
         )
 
         self.assertEqual("proj-patient-id", test_project.id)
@@ -395,7 +380,6 @@ class TestProject(TestCase):
         self.assertEqual(1630515986.9949625, test_project.updated_at)
         self.assertEqual("user-1", test_project.created_by)
         self.assertEqual("user-1", test_project.updated_by)
-        self.assertEqual(example_metrics, test_project.metrics)
 
     def test_cohort_attributes(self):
         """
@@ -424,19 +408,6 @@ class TestProject(TestCase):
         Test attributes for an initialized Cohort Patient.
 
         """
-        example_metrics = MetricSet(
-            [
-                Metric(
-                    type="LAST_UPLOAD",
-                    data_type="APPLEWATCH_TREMOR",
-                    value=1648235452.965804,
-                    time_interval="FOURTEEN_DAYS",
-                    created_at=1673467628.837126,
-                    updated_at=1673467628.837126,
-                    id="1bfcf11f-8d5c-4714-b774-6b47e03c5900",
-                ),
-            ]
-        )
         test_project = CohortPatientMetadata(
             id="cohort-patient-id",
             created_at=1630515986.9949625,
@@ -444,7 +415,6 @@ class TestProject(TestCase):
             created_by="user-1",
             updated_by="user-1",
             started_at=1630515986.9949625,
-            metrics=example_metrics,
         )
 
         self.assertEqual("cohort-patient-id", test_project.id)
@@ -452,7 +422,6 @@ class TestProject(TestCase):
         self.assertEqual(1630515986.9949625, test_project.updated_at)
         self.assertEqual("user-1", test_project.created_by)
         self.assertEqual("user-1", test_project.updated_by)
-        self.assertEqual(example_metrics, test_project.metrics)
 
     def test_get_project_patients_basic(self):
         """
@@ -463,17 +432,6 @@ class TestProject(TestCase):
         project_patients_expected = [
             {
                 "id": "patient-1",
-                "metrics": [
-                    {
-                        "id": "metric-1",
-                        "updated_at": 1673467628.837126,
-                        "created_at": 1673467628.837126,
-                        "type": "LAST_UPLOAD",
-                        "data_type": "APPLEWATCH_TREMOR",
-                        "value": 1648235452.965804,
-                        "time_interval": "FOURTEEN_DAYS",
-                    },
-                ],
                 "code_name": "code name 1",
                 "created_at": 1673467625.063822,
                 "updated_at": 1673467625.063822,
@@ -482,17 +440,6 @@ class TestProject(TestCase):
             },
             {
                 "id": "patient-2",
-                "metrics": [
-                    {
-                        "id": "metric-2",
-                        "updated_at": 1673467628.837126,
-                        "created_at": 1673467628.837126,
-                        "type": "LAST_UPLOAD",
-                        "data_type": "APPLEWATCH_TREMOR",
-                        "value": 1648235452.965804,
-                        "time_interval": "FOURTEEN_DAYS",
-                    },
-                ],
                 "code_name": "code name 2",
                 "created_at": 1673467625.063822,
                 "updated_at": 1673467625.063822,
@@ -507,19 +454,6 @@ class TestProject(TestCase):
                     "projectPatients": [
                         {
                             "patient": {"id": "patient-1"},
-                            "metricList": {
-                                "metrics": [
-                                    {
-                                        "id": "metric-1",
-                                        "updated_at": 1673467628.837126,
-                                        "created_at": 1673467628.837126,
-                                        "type": "LAST_UPLOAD",
-                                        "data_type": "APPLEWATCH_TREMOR",
-                                        "value": 1648235452.965804,
-                                        "time_interval": "FOURTEEN_DAYS",
-                                    },
-                                ]
-                            },
                             "code_name": "code name 1",
                             "created_at": 1673467625.063822,
                             "updated_at": 1673467625.063822,
@@ -528,19 +462,6 @@ class TestProject(TestCase):
                         },
                         {
                             "patient": {"id": "patient-2"},
-                            "metricList": {
-                                "metrics": [
-                                    {
-                                        "id": "metric-2",
-                                        "updated_at": 1673467628.837126,
-                                        "created_at": 1673467628.837126,
-                                        "type": "LAST_UPLOAD",
-                                        "data_type": "APPLEWATCH_TREMOR",
-                                        "value": 1648235452.965804,
-                                        "time_interval": "FOURTEEN_DAYS",
-                                    },
-                                ]
-                            },
                             "code_name": "code name 2",
                             "created_at": 1673467625.063822,
                             "updated_at": 1673467625.063822,
@@ -571,17 +492,6 @@ class TestProject(TestCase):
         project_patients_expected = [
             {
                 "id": "patient-1",
-                "metrics": [
-                    {
-                        "id": "metric-1",
-                        "updated_at": 1673467628.837126,
-                        "created_at": 1673467628.837126,
-                        "type": "LAST_UPLOAD",
-                        "data_type": "APPLEWATCH_TREMOR",
-                        "value": 1648235452.965804,
-                        "time_interval": "FOURTEEN_DAYS",
-                    },
-                ],
                 "code_name": "code name 1",
                 "created_at": 1673467625.063822,
                 "updated_at": 1673467625.063822,
@@ -590,17 +500,6 @@ class TestProject(TestCase):
             },
             {
                 "id": "patient-2",
-                "metrics": [
-                    {
-                        "id": "metric-2",
-                        "updated_at": 1673467628.837126,
-                        "created_at": 1673467628.837126,
-                        "type": "LAST_UPLOAD",
-                        "data_type": "APPLEWATCH_TREMOR",
-                        "value": 1648235452.965804,
-                        "time_interval": "FOURTEEN_DAYS",
-                    },
-                ],
                 "code_name": "code name 2",
                 "created_at": 1673467625.063822,
                 "updated_at": 1673467625.063822,
@@ -616,19 +515,6 @@ class TestProject(TestCase):
                         "projectPatients": [
                             {
                                 "patient": {"id": "patient-1"},
-                                "metricList": {
-                                    "metrics": [
-                                        {
-                                            "id": "metric-1",
-                                            "updated_at": 1673467628.837126,
-                                            "created_at": 1673467628.837126,
-                                            "type": "LAST_UPLOAD",
-                                            "data_type": "APPLEWATCH_TREMOR",
-                                            "value": 1648235452.965804,
-                                            "time_interval": "FOURTEEN_DAYS",
-                                        },
-                                    ]
-                                },
                                 "code_name": "code name 1",
                                 "created_at": 1673467625.063822,
                                 "updated_at": 1673467625.063822,
@@ -646,19 +532,6 @@ class TestProject(TestCase):
                         "projectPatients": [
                             {
                                 "patient": {"id": "patient-2"},
-                                "metricList": {
-                                    "metrics": [
-                                        {
-                                            "id": "metric-2",
-                                            "updated_at": 1673467628.837126,
-                                            "created_at": 1673467628.837126,
-                                            "type": "LAST_UPLOAD",
-                                            "data_type": "APPLEWATCH_TREMOR",
-                                            "value": 1648235452.965804,
-                                            "time_interval": "FOURTEEN_DAYS",
-                                        },
-                                    ]
-                                },
                                 "code_name": "code name 2",
                                 "created_at": 1673467625.063822,
                                 "updated_at": 1673467625.063822,
@@ -690,17 +563,6 @@ class TestProject(TestCase):
         cohort_patients_expected = [
             {
                 "id": "patient-1",
-                "metrics": [
-                    {
-                        "id": "metric-1",
-                        "updated_at": 1673467628.837126,
-                        "created_at": 1673467628.837126,
-                        "type": "LAST_UPLOAD",
-                        "data_type": "APPLEWATCH_TREMOR",
-                        "value": 1648235452.965804,
-                        "time_interval": "FOURTEEN_DAYS",
-                    },
-                ],
                 "code_name": "code name 1",
                 "created_at": 1673467625.063822,
                 "updated_at": 1673467625.063822,
@@ -709,17 +571,6 @@ class TestProject(TestCase):
             },
             {
                 "id": "patient-2",
-                "metrics": [
-                    {
-                        "id": "metric-2",
-                        "updated_at": 1673467628.837126,
-                        "created_at": 1673467628.837126,
-                        "type": "LAST_UPLOAD",
-                        "data_type": "APPLEWATCH_TREMOR",
-                        "value": 1648235452.965804,
-                        "time_interval": "FOURTEEN_DAYS",
-                    },
-                ],
                 "code_name": "code name 2",
                 "created_at": 1673467625.063822,
                 "updated_at": 1673467625.063822,
@@ -734,19 +585,6 @@ class TestProject(TestCase):
                     "cohortPatients": [
                         {
                             "patient": {"id": "patient-1"},
-                            "metricList": {
-                                "metrics": [
-                                    {
-                                        "id": "metric-1",
-                                        "updated_at": 1673467628.837126,
-                                        "created_at": 1673467628.837126,
-                                        "type": "LAST_UPLOAD",
-                                        "data_type": "APPLEWATCH_TREMOR",
-                                        "value": 1648235452.965804,
-                                        "time_interval": "FOURTEEN_DAYS",
-                                    },
-                                ]
-                            },
                             "code_name": "code name 1",
                             "created_at": 1673467625.063822,
                             "updated_at": 1673467625.063822,
@@ -755,19 +593,6 @@ class TestProject(TestCase):
                         },
                         {
                             "patient": {"id": "patient-2"},
-                            "metricList": {
-                                "metrics": [
-                                    {
-                                        "id": "metric-2",
-                                        "updated_at": 1673467628.837126,
-                                        "created_at": 1673467628.837126,
-                                        "type": "LAST_UPLOAD",
-                                        "data_type": "APPLEWATCH_TREMOR",
-                                        "value": 1648235452.965804,
-                                        "time_interval": "FOURTEEN_DAYS",
-                                    },
-                                ]
-                            },
                             "code_name": "code name 2",
                             "created_at": 1673467625.063822,
                             "updated_at": 1673467625.063822,
@@ -798,17 +623,6 @@ class TestProject(TestCase):
         cohort_patients_expected = [
             {
                 "id": "patient-1",
-                "metrics": [
-                    {
-                        "id": "metric-1",
-                        "updated_at": 1673467628.837126,
-                        "created_at": 1673467628.837126,
-                        "type": "LAST_UPLOAD",
-                        "data_type": "APPLEWATCH_TREMOR",
-                        "value": 1648235452.965804,
-                        "time_interval": "FOURTEEN_DAYS",
-                    },
-                ],
                 "code_name": "code name 1",
                 "created_at": 1673467625.063822,
                 "updated_at": 1673467625.063822,
@@ -817,17 +631,6 @@ class TestProject(TestCase):
             },
             {
                 "id": "patient-2",
-                "metrics": [
-                    {
-                        "id": "metric-2",
-                        "updated_at": 1673467628.837126,
-                        "created_at": 1673467628.837126,
-                        "type": "LAST_UPLOAD",
-                        "data_type": "APPLEWATCH_TREMOR",
-                        "value": 1648235452.965804,
-                        "time_interval": "FOURTEEN_DAYS",
-                    },
-                ],
                 "code_name": "code name 2",
                 "created_at": 1673467625.063822,
                 "updated_at": 1673467625.063822,
@@ -843,19 +646,6 @@ class TestProject(TestCase):
                         "cohortPatients": [
                             {
                                 "patient": {"id": "patient-1"},
-                                "metricList": {
-                                    "metrics": [
-                                        {
-                                            "id": "metric-1",
-                                            "updated_at": 1673467628.837126,
-                                            "created_at": 1673467628.837126,
-                                            "type": "LAST_UPLOAD",
-                                            "data_type": "APPLEWATCH_TREMOR",
-                                            "value": 1648235452.965804,
-                                            "time_interval": "FOURTEEN_DAYS",
-                                        },
-                                    ]
-                                },
                                 "code_name": "code name 1",
                                 "created_at": 1673467625.063822,
                                 "updated_at": 1673467625.063822,
@@ -873,19 +663,6 @@ class TestProject(TestCase):
                         "cohortPatients": [
                             {
                                 "patient": {"id": "patient-2"},
-                                "metricList": {
-                                    "metrics": [
-                                        {
-                                            "id": "metric-2",
-                                            "updated_at": 1673467628.837126,
-                                            "created_at": 1673467628.837126,
-                                            "type": "LAST_UPLOAD",
-                                            "data_type": "APPLEWATCH_TREMOR",
-                                            "value": 1648235452.965804,
-                                            "time_interval": "FOURTEEN_DAYS",
-                                        },
-                                    ]
-                                },
                                 "code_name": "code name 2",
                                 "created_at": 1673467625.063822,
                                 "updated_at": 1673467625.063822,

--- a/tests/resources/test_project.py
+++ b/tests/resources/test_project.py
@@ -9,7 +9,6 @@ from runeq.config import Config
 from runeq.resources.client import GraphClient
 from runeq.resources.project import (
     Cohort,
-    CohortPatientMetadata,
     CohortSet,
     Project,
     ProjectPatientMetadata,
@@ -368,6 +367,7 @@ class TestProject(TestCase):
         """
         test_project = ProjectPatientMetadata(
             id="proj-patient-id",
+            project_code_name="Code Name",
             created_at=1630515986.9949625,
             updated_at=1630515986.9949625,
             created_by="user-1",
@@ -376,6 +376,7 @@ class TestProject(TestCase):
         )
 
         self.assertEqual("proj-patient-id", test_project.id)
+        self.assertEqual("Code Name", test_project.project_code_name)
         self.assertEqual(1630515986.9949625, test_project.created_at)
         self.assertEqual(1630515986.9949625, test_project.updated_at)
         self.assertEqual("user-1", test_project.created_by)
@@ -403,26 +404,6 @@ class TestProject(TestCase):
         self.assertEqual("user-1", test_cohort.created_by)
         self.assertEqual("user-1", test_cohort.updated_by)
 
-    def test_cohort_patient_attributes(self):
-        """
-        Test attributes for an initialized Cohort Patient.
-
-        """
-        test_project = CohortPatientMetadata(
-            id="cohort-patient-id",
-            created_at=1630515986.9949625,
-            updated_at=1630515986.9949625,
-            created_by="user-1",
-            updated_by="user-1",
-            started_at=1630515986.9949625,
-        )
-
-        self.assertEqual("cohort-patient-id", test_project.id)
-        self.assertEqual(1630515986.9949625, test_project.created_at)
-        self.assertEqual(1630515986.9949625, test_project.updated_at)
-        self.assertEqual("user-1", test_project.created_by)
-        self.assertEqual("user-1", test_project.updated_by)
-
     def test_get_project_patients_basic(self):
         """
         Test get project patients for the initialized user.
@@ -432,7 +413,7 @@ class TestProject(TestCase):
         project_patients_expected = [
             {
                 "id": "patient-1",
-                "code_name": "code name 1",
+                "project_code_name": "code name 1",
                 "created_at": 1673467625.063822,
                 "updated_at": 1673467625.063822,
                 "created_by": "user 1",
@@ -440,7 +421,7 @@ class TestProject(TestCase):
             },
             {
                 "id": "patient-2",
-                "code_name": "code name 2",
+                "project_code_name": "code name 2",
                 "created_at": 1673467625.063822,
                 "updated_at": 1673467625.063822,
                 "created_by": "user 2",
@@ -454,7 +435,7 @@ class TestProject(TestCase):
                     "projectPatients": [
                         {
                             "patient": {"id": "patient-1"},
-                            "code_name": "code name 1",
+                            "project_code_name": "code name 1",
                             "created_at": 1673467625.063822,
                             "updated_at": 1673467625.063822,
                             "created_by": "user 1",
@@ -462,7 +443,7 @@ class TestProject(TestCase):
                         },
                         {
                             "patient": {"id": "patient-2"},
-                            "code_name": "code name 2",
+                            "project_code_name": "code name 2",
                             "created_at": 1673467625.063822,
                             "updated_at": 1673467625.063822,
                             "created_by": "user 2",
@@ -492,7 +473,7 @@ class TestProject(TestCase):
         project_patients_expected = [
             {
                 "id": "patient-1",
-                "code_name": "code name 1",
+                "project_code_name": "code name 1",
                 "created_at": 1673467625.063822,
                 "updated_at": 1673467625.063822,
                 "created_by": "user 1",
@@ -500,7 +481,7 @@ class TestProject(TestCase):
             },
             {
                 "id": "patient-2",
-                "code_name": "code name 2",
+                "project_code_name": "code name 2",
                 "created_at": 1673467625.063822,
                 "updated_at": 1673467625.063822,
                 "created_by": "user 2",
@@ -515,7 +496,7 @@ class TestProject(TestCase):
                         "projectPatients": [
                             {
                                 "patient": {"id": "patient-1"},
-                                "code_name": "code name 1",
+                                "project_code_name": "code name 1",
                                 "created_at": 1673467625.063822,
                                 "updated_at": 1673467625.063822,
                                 "created_by": "user 1",
@@ -532,7 +513,7 @@ class TestProject(TestCase):
                         "projectPatients": [
                             {
                                 "patient": {"id": "patient-2"},
-                                "code_name": "code name 2",
+                                "project_code_name": "code name 2",
                                 "created_at": 1673467625.063822,
                                 "updated_at": 1673467625.063822,
                                 "created_by": "user 2",
@@ -563,7 +544,7 @@ class TestProject(TestCase):
         cohort_patients_expected = [
             {
                 "id": "patient-1",
-                "code_name": "code name 1",
+                "project_code_name": "code name 1",
                 "created_at": 1673467625.063822,
                 "updated_at": 1673467625.063822,
                 "created_by": "user 1",
@@ -571,7 +552,7 @@ class TestProject(TestCase):
             },
             {
                 "id": "patient-2",
-                "code_name": "code name 2",
+                "project_code_name": "code name 2",
                 "created_at": 1673467625.063822,
                 "updated_at": 1673467625.063822,
                 "created_by": "user 2",
@@ -585,7 +566,7 @@ class TestProject(TestCase):
                     "cohortPatients": [
                         {
                             "patient": {"id": "patient-1"},
-                            "code_name": "code name 1",
+                            "project_code_name": "code name 1",
                             "created_at": 1673467625.063822,
                             "updated_at": 1673467625.063822,
                             "created_by": "user 1",
@@ -593,7 +574,7 @@ class TestProject(TestCase):
                         },
                         {
                             "patient": {"id": "patient-2"},
-                            "code_name": "code name 2",
+                            "project_code_name": "code name 2",
                             "created_at": 1673467625.063822,
                             "updated_at": 1673467625.063822,
                             "created_by": "user 2",
@@ -623,7 +604,7 @@ class TestProject(TestCase):
         cohort_patients_expected = [
             {
                 "id": "patient-1",
-                "code_name": "code name 1",
+                "project_code_name": "code name 1",
                 "created_at": 1673467625.063822,
                 "updated_at": 1673467625.063822,
                 "created_by": "user 1",
@@ -631,7 +612,7 @@ class TestProject(TestCase):
             },
             {
                 "id": "patient-2",
-                "code_name": "code name 2",
+                "project_code_name": "code name 2",
                 "created_at": 1673467625.063822,
                 "updated_at": 1673467625.063822,
                 "created_by": "user 2",
@@ -646,7 +627,7 @@ class TestProject(TestCase):
                         "cohortPatients": [
                             {
                                 "patient": {"id": "patient-1"},
-                                "code_name": "code name 1",
+                                "project_code_name": "code name 1",
                                 "created_at": 1673467625.063822,
                                 "updated_at": 1673467625.063822,
                                 "created_by": "user 1",
@@ -663,7 +644,7 @@ class TestProject(TestCase):
                         "cohortPatients": [
                             {
                                 "patient": {"id": "patient-2"},
-                                "code_name": "code name 2",
+                                "project_code_name": "code name 2",
                                 "created_at": 1673467625.063822,
                                 "updated_at": 1673467625.063822,
                                 "created_by": "user 2",

--- a/tests/stream/test_v1.py
+++ b/tests/stream/test_v1.py
@@ -487,7 +487,7 @@ class TestStreamV1Client(TestCase):
         expected = [
             {"lower": 1, "higher": 2, "label": "ints"},
             {"lower": 3.5, "higher": 6.7, "label": "floats"},
-            {"lower": np.NaN, "higher": 8.9, "label": "missing data"},
+            {"lower": np.nan, "higher": 8.9, "label": "missing data"},
         ]
 
         for test_num, resource_creator in enumerate(


### PR DESCRIPTION
Making a number of breaking changes to Project and Cohort resource classes

* Metrics have been deprecated: they are also being removed from the underlying API.
* Removed the `CohortPatientMetadata[Set]` classes: they serve the same function as `ProjectPatientMetadata[Set]`, and there's no reason to maintain both. I considered leaving it in place, and just making it an alias of the project class.... but I don't think this part of the SDK is heavily used, and I figured I'd clean it up while I'm making other breaking changes. LMK if you disagree!
* The `code_name` attribute on the ProjectPatientMetadata object has been renamed to `project_code_name`, for clarity. The column in the dataframe has also been renamed.
