### PR TITLE
[SW-7132] Fix empty event list handling

### DIFF
--- a/runeq/resources/event.py
+++ b/runeq/resources/event.py
@@ -265,7 +265,9 @@ def _iter_events(
             **variables,
         )
 
-        event_list = result["patient"]["eventList"]
+        # If the patient has no events, GraphQL will return None (not empty) - we need to explicitly
+        # check for None here, and otherwise set it to an empty dictionary.
+        event_list = result["patient"].get("eventList") or {}
         for event in event_list.get("events", []):
             _reformat_event(event)
             yield Event(patient_id=patient_id, **event)

--- a/tests/resources/test_event.py
+++ b/tests/resources/test_event.py
@@ -248,7 +248,7 @@ class TestEvent(TestCase):
         self.mock_client.execute = mock.Mock(
             side_effect=[
                 # empty response for the first "chunk" of time in the query range
-                {"patient": {"eventList": {"events": []}}},
+                {"patient": {"eventList": None}},
                 {
                     "patient": {
                         "eventList": {
@@ -450,7 +450,7 @@ class TestEvent(TestCase):
 
         """
         self.mock_client.execute = mock.Mock(
-            return_value={"patient": {"eventList": {"events": []}}},
+            return_value={"patient": {"eventList": None}},
         )
 
         # activity


### PR DESCRIPTION
This fixes a bug when handling an empty event list response from GraphQL when fetching patient events.

https://runelabs.atlassian.net/browse/SW-7132