### PR TITLE
[SW-7024] Fix warnings in runeq

### DIFF
--- a/runeq/resources/stream_metadata.py
+++ b/runeq/resources/stream_metadata.py
@@ -405,7 +405,15 @@ class StreamMetadata(ItemBase):
         for resp in get_stream_data(client=stream_client, **params):
             all_stream_dfs.append(pd.read_csv(StringIO(resp), sep=","))
 
-        stream_df = pd.concat(all_stream_dfs, axis=0, ignore_index=True)
+        # Filter out empty DataFrames before concatenation
+        non_empty_dfs = [df for df in all_stream_dfs if not df.empty]
+
+        # Concatenate only non-empty DataFrames
+        if non_empty_dfs:
+            stream_df = pd.concat(non_empty_dfs, axis=0, ignore_index=True)
+        else:
+            # Handle the case where all DataFrames are empty
+            stream_df = pd.DataFrame()
 
         # Convert "dict" dimensions to native dicts (from strings)
         for dim in self.stream_type.dimensions:
@@ -470,7 +478,15 @@ class StreamMetadata(ItemBase):
         for resp in responses:
             all_stream_dfs.append(pd.read_csv(StringIO(resp), sep=","))
 
-        stream_df = pd.concat(all_stream_dfs, axis=0, ignore_index=True)
+        # Filter out empty DataFrames before concatenation
+        non_empty_dfs = [df for df in all_stream_dfs if not df.empty]
+
+        # Concatenate only non-empty DataFrames
+        if non_empty_dfs:
+            stream_df = pd.concat(non_empty_dfs, axis=0, ignore_index=True)
+        else:
+            # Handle the case where all DataFrames are empty
+            stream_df = pd.DataFrame()
         # Add metadata before returning the dataframe
         return self._add_metadata_to_dataframe(stream_df)
 
@@ -612,7 +628,17 @@ class StreamMetadataSet(ItemSet):
             )
             all_stream_dfs.append(stream_df)
 
-        return pd.concat(all_stream_dfs, axis=0, ignore_index=True)
+        # Filter out empty DataFrames before concatenation
+        non_empty_dfs = [df for df in all_stream_dfs if not df.empty]
+
+        # Concatenate only non-empty DataFrames
+        if non_empty_dfs:
+            stream_df = pd.concat(non_empty_dfs, axis=0, ignore_index=True)
+        else:
+            # Handle the case where all DataFrames are empty
+            stream_df = pd.DataFrame()
+
+        return stream_df
 
     def get_batch_availability_dataframe(
         self,
@@ -679,7 +705,15 @@ class StreamMetadataSet(ItemSet):
         for resp in responses:
             all_stream_dfs.append(pd.read_csv(StringIO(resp), sep=","))
 
-        stream_df = pd.concat(all_stream_dfs, axis=0, ignore_index=True)
+        # Filter out empty DataFrames before concatenation
+        non_empty_dfs = [df for df in all_stream_dfs if not df.empty]
+
+        # Concatenate only non-empty DataFrames
+        if non_empty_dfs:
+            stream_df = pd.concat(non_empty_dfs, axis=0, ignore_index=True)
+        else:
+            # Handle the case where all DataFrames are empty
+            stream_df = pd.DataFrame()
 
         return stream_df
 
@@ -1078,7 +1112,15 @@ def get_stream_availability_dataframe(
         for resp in responses:
             all_stream_dfs.append(pd.read_csv(StringIO(resp), sep=","))
 
-        stream_df = pd.concat(all_stream_dfs, axis=0, ignore_index=True)
+        # Filter out empty DataFrames before concatenation
+        non_empty_dfs = [df for df in all_stream_dfs if not df.empty]
+
+        # Concatenate only non-empty DataFrames
+        if non_empty_dfs:
+            stream_df = pd.concat(non_empty_dfs, axis=0, ignore_index=True)
+        else:
+            # Handle the case where all DataFrames are empty
+            stream_df = pd.DataFrame()
 
         return stream_df
 


### PR DESCRIPTION
[Jira ticket](https://runelabs.atlassian.net/browse/SW-7024) 

This fixes the warning `FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.` from coming up when retrieving stream data with the get datastream runeq function.