### PR TITLE
feat: item set generics

### DIFF
--- a/runeq/resources/common.py
+++ b/runeq/resources/common.py
@@ -5,7 +5,7 @@ Common utilities and base classes.
 
 from abc import ABC, abstractmethod
 from collections import OrderedDict
-from typing import Any, Dict, Iterable, Iterator, List, Type, Union
+from typing import Any, Dict, Generic, Iterable, Iterator, List, Type, TypeVar, Union
 
 import pandas as pd
 
@@ -81,16 +81,19 @@ class ItemBase:
         return self._attributes
 
 
-class ItemSet(ABC):
+Item = TypeVar("Item", bound=ItemBase)
+
+
+class ItemSet(ABC, Generic[Item]):
     """
     Base class for representing a set of items.
 
     """
 
     # The Items in this set. Maps id to item.
-    _items: Dict[str, ItemBase]
+    _items: Dict[str, Item]
 
-    def __init__(self, items: Iterable[ItemBase] = ()):
+    def __init__(self, items: Iterable[Item] = ()):
         """
         Initialize items set representational state.
 
@@ -99,7 +102,7 @@ class ItemSet(ABC):
         for item in items:
             self.add(item)
 
-    def __iter__(self) -> Iterator[ItemBase]:
+    def __iter__(self) -> Iterator[Item]:
         """
         Iterate over the items of the set.
 
@@ -129,7 +132,7 @@ class ItemSet(ABC):
         """
         pass
 
-    def get(self, id: str) -> ItemBase:
+    def get(self, id: str) -> Item:
         """
         Get an item by id.
 
@@ -147,7 +150,7 @@ class ItemSet(ABC):
             f"{self._item_class.__name__} with ID {id}"
         )
 
-    def add(self, item: ItemBase):
+    def add(self, item: Item):
         """
         Add a single item to the set. Must be the same type as other members
         of the collection
@@ -160,7 +163,7 @@ class ItemSet(ABC):
 
         self._items[item.id] = item
 
-    def update(self, items: Iterable[ItemBase]):
+    def update(self, items: Iterable[Item]):
         """
         Add an iterable of item(s) to this set. All items must be the same
         class as members of this collection.
@@ -175,7 +178,7 @@ class ItemSet(ABC):
 
             self._items[item.id] = item
 
-    def remove(self, *items: Union[str, ItemBase]):
+    def remove(self, *items: Union[str, Item]):
         """
         Remove item(s) from this set.
 
@@ -185,7 +188,7 @@ class ItemSet(ABC):
                 # item is an id
                 self._items.pop(item, None)
             else:
-                # item is an instance of ItemBase
+                # item is an instance of Item
                 self._items.pop(item.id, None)
 
     def ids(self) -> Iterator[str]:

--- a/runeq/resources/event.py
+++ b/runeq/resources/event.py
@@ -112,7 +112,7 @@ class Event(ItemBase):
         )
 
 
-class EventSet(ItemSet):
+class EventSet(ItemSet[Event]):
     """
     A collection of Events.
 

--- a/runeq/resources/org.py
+++ b/runeq/resources/org.py
@@ -80,7 +80,7 @@ class Org(ItemBase):
         return org_id
 
 
-class OrgSet(ItemSet):
+class OrgSet(ItemSet[Org]):
     """
     A collection of Organizations.
 

--- a/runeq/resources/patient.py
+++ b/runeq/resources/patient.py
@@ -98,7 +98,7 @@ class Device(ItemBase):
         )
 
 
-class DeviceSet(ItemSet):
+class DeviceSet(ItemSet[Device]):
     """
     A collection of Devices.
 
@@ -215,7 +215,7 @@ class Patient(ItemBase):
         return attrs
 
 
-class PatientSet(ItemSet):
+class PatientSet(ItemSet[Patient]):
     """
     A collection of Patients.
 

--- a/runeq/resources/project.py
+++ b/runeq/resources/project.py
@@ -83,7 +83,7 @@ class ProjectPatientMetadata(ItemBase):
         return attrs
 
 
-class ProjectPatientMetadataSet(ItemSet):
+class ProjectPatientMetadataSet(ItemSet[ProjectPatientMetadata]):
     """
     A collection of ProjectPatientMetadata.
 
@@ -160,7 +160,7 @@ class Cohort(ItemBase):
         return f"{self.__class__.__name__}" f'(id="{self.id}", title="{self.title}")'
 
 
-class CohortSet(ItemSet):
+class CohortSet(ItemSet[Cohort]):
     """
     A collection of Cohorts.
 
@@ -267,7 +267,7 @@ class Project(ItemBase):
         return attrs
 
 
-class ProjectSet(ItemSet):
+class ProjectSet(ItemSet[Project]):
     """
     A collection of Projects.
 

--- a/runeq/resources/stream_metadata.py
+++ b/runeq/resources/stream_metadata.py
@@ -100,7 +100,7 @@ class StreamType(ItemBase):
         return attrs
 
 
-class StreamTypeSet(ItemSet):
+class StreamTypeSet(ItemSet[StreamType]):
     """
     A collection of StreamTypes.
 
@@ -475,7 +475,7 @@ class StreamMetadata(ItemBase):
         return self._add_metadata_to_dataframe(stream_df)
 
 
-class StreamMetadataSet(ItemSet):
+class StreamMetadataSet(ItemSet[StreamMetadata]):
     """
     A collection of StreamMetadata.
 

--- a/tests/resources/test_common.py
+++ b/tests/resources/test_common.py
@@ -38,7 +38,7 @@ class PatientItem(ItemBase):
         super().__init__(id=id, name=name, **attributes)
 
 
-class PatientItemSet(ItemSet):
+class PatientItemSet(ItemSet[PatientItem]):
     """
     Test ItemSet class that represents a Patient
 


### PR DESCRIPTION
When working with concrete implementations of ItemSet, type checkers and LSPs like pyright/pylance, mypy, etc. see the result of a `get` or other operations as being of instance `ItemBase`. This is accurate but it means that accessing properties declared on a subclass of ItemBase is flagged as a type error, even though the item we got back was of that subclass.

For example, suppose we have the following code:

```python
from typing import cast
from runeq.resources.stream_metadata import get_patient_stream_metadata, StreamMetadata, ItemBase

stream_metadata_set = get_patient_stream_metadata(patient_id)

for stream_metadata in stream_metadata_set:
    print(isinstance(stream_metadata, StreamMetadata))  # True
    print(isinstance(stream_metadata, ItemBase))  # True
    category = stream_metadata.parameters.get("category")
    #                          ~~~~~~~~~~
    # Pyright: Cannot access attribute "parameters" for class "ItemBase"
    #   Attribute "parameters" is unknown
    stream_metadata = cast(StreamMetadata, stream_metadata)
    category = stream_metadata.parameters.get("category")  # All good
```
At run time, there is no issue. But while developing with the library, it's handy for the type checker to know what's up.

This PR adds generics to the `ItemSet` base to enable type checkers to know the concrete type of the items in the set.